### PR TITLE
feat: Cloudflare Pages によるPRプレビューデプロイを追加

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,66 @@
+name: Deploy Preview to Cloudflare Pages
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs --project-name=japan-cityos-sdk
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.deployment-url }}';
+            const body = `🔍 **Preview deployed!**\n\n${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes('Preview deployed!'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
         with:
           script: |
-            const url = '${{ steps.deploy.outputs.deployment-url }}';
+            const url = process.env.DEPLOY_URL;
             const marker = '<!-- cf-pages-preview-comment -->';
             const body = `${marker}\n🔍 **Preview deployed!**\n\n${url}`;
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy docs --project-name=japan-cityos-sdk
+          command: pages deploy docs --project-name=japan-cityos-sdk --branch=${{ github.head_ref || 'main' }}
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
@@ -42,13 +42,18 @@ jobs:
         with:
           script: |
             const url = '${{ steps.deploy.outputs.deployment-url }}';
-            const body = `🔍 **Preview deployed!**\n\n${url}`;
-            const { data: comments } = await github.rest.issues.listComments({
+            const marker = '<!-- cf-pages-preview-comment -->';
+            const body = `${marker}\n🔍 **Preview deployed!**\n\n${url}`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
-            const existing = comments.find(c => c.body.includes('Preview deployed!'));
+            const existing = comments.find(c =>
+              c.user?.login === 'github-actions[bot]' &&
+              c.body?.includes(marker)
+            );
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- PRごとにデモ画面のプレビューURLを自動生成する GitHub Actions ワークフローを追加
- Cloudflare Pages にデプロイし、PRコメントにプレビューURLを投稿
- #94 (Cloudflare Workers) の代替として、静的サイトに適した Cloudflare Pages を使用

## セットアップ手順
1. Cloudflare Pages で `japan-cityos-sdk` プロジェクトを作成（Direct Upload）
2. GitHub Secrets に `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_API_TOKEN` を登録

## Test plan
- [ ] Cloudflare Pages プロジェクトの作成
- [ ] GitHub Secrets の設定
- [ ] PRを作ってプレビューURLがコメントされることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * プルリクエストおよび main ブランチへのプッシュ時に、自動でプレビュー環境へデプロイする GitHub Actions ワークフローを追加しました。
  * プレビュー作成時、該当プルリクエストにデプロイ先のURLをボットが投稿または更新し、常に最新のプレビューリンクを参照できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->