### PR TITLE
feat: japanese-admins の GeoJSON データ取得機能を実装 (#99)

### DIFF
--- a/docs/utils/japaneseAdminsUtils.d.ts
+++ b/docs/utils/japaneseAdminsUtils.d.ts
@@ -11,7 +11,7 @@ export declare function buildJapaneseAdminsUrl(code: string): string;
 /**
  * 都道府県コードを指定して japanese-admins から都道府県境界の GeoJSON を取得する
  * @param prefCode 都道府県コード（2桁、例: '01'）
- * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時・バリデーションエラー時）
  *
  * @example
  * const hokkaido = await fetchPrefectureGeojson('01'); // 北海道の境界を取得
@@ -20,7 +20,7 @@ export declare function fetchPrefectureGeojson(prefCode: string): Promise<GeoJSO
 /**
  * 市区町村コードを指定して japanese-admins から市区町村境界の GeoJSON を取得する
  * @param adminCode 市区町村コード（5桁、例: '01101'）
- * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時・バリデーションエラー時）
  *
  * @example
  * const sapporoChuoku = await fetchMunicipalityGeojson('01101'); // 札幌市中央区の境界を取得

--- a/docs/utils/japaneseAdminsUtils.d.ts
+++ b/docs/utils/japaneseAdminsUtils.d.ts
@@ -1,0 +1,28 @@
+/**
+ * 都道府県コードまたは市区町村コードから japanese-admins の GeoJSON URL を生成する
+ * @param code 都道府県コード（2桁）または市区町村コード（5桁）
+ * @returns GeoJSON の URL
+ *
+ * @example
+ * buildJapaneseAdminsUrl('01') // => 'https://geolonia.github.io/japanese-admins/01/01.json'
+ * buildJapaneseAdminsUrl('01101') // => 'https://geolonia.github.io/japanese-admins/01/01101.json'
+ */
+export declare function buildJapaneseAdminsUrl(code: string): string;
+/**
+ * 都道府県コードを指定して japanese-admins から都道府県境界の GeoJSON を取得する
+ * @param prefCode 都道府県コード（2桁、例: '01'）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ *
+ * @example
+ * const hokkaido = await fetchPrefectureGeojson('01'); // 北海道の境界を取得
+ */
+export declare function fetchPrefectureGeojson(prefCode: string): Promise<GeoJSON.FeatureCollection | null>;
+/**
+ * 市区町村コードを指定して japanese-admins から市区町村境界の GeoJSON を取得する
+ * @param adminCode 市区町村コード（5桁、例: '01101'）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ *
+ * @example
+ * const sapporoChuoku = await fetchMunicipalityGeojson('01101'); // 札幌市中央区の境界を取得
+ */
+export declare function fetchMunicipalityGeojson(adminCode: string): Promise<GeoJSON.FeatureCollection | null>;

--- a/src/utils/japaneseAdminsUtils.ts
+++ b/src/utils/japaneseAdminsUtils.ts
@@ -1,0 +1,49 @@
+import { fetchJson } from './fetchJson';
+
+const JAPANESE_ADMINS_BASE_URL = 'https://geolonia.github.io/japanese-admins';
+
+/**
+ * 都道府県コードまたは市区町村コードから japanese-admins の GeoJSON URL を生成する
+ * @param code 都道府県コード（2桁）または市区町村コード（5桁）
+ * @returns GeoJSON の URL
+ *
+ * @example
+ * buildJapaneseAdminsUrl('01') // => 'https://geolonia.github.io/japanese-admins/01/01.json'
+ * buildJapaneseAdminsUrl('01101') // => 'https://geolonia.github.io/japanese-admins/01/01101.json'
+ */
+export function buildJapaneseAdminsUrl(code: string): string {
+  const prefCode = code.slice(0, 2);
+  return `${JAPANESE_ADMINS_BASE_URL}/${prefCode}/${code}.json`;
+}
+
+/**
+ * 都道府県コードを指定して japanese-admins から都道府県境界の GeoJSON を取得する
+ * @param prefCode 都道府県コード（2桁、例: '01'）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ *
+ * @example
+ * const hokkaido = await fetchPrefectureGeojson('01'); // 北海道の境界を取得
+ */
+export async function fetchPrefectureGeojson(
+  prefCode: string
+): Promise<GeoJSON.FeatureCollection | null> {
+  const url = buildJapaneseAdminsUrl(prefCode);
+  const data = await fetchJson(url);
+  return data;
+}
+
+/**
+ * 市区町村コードを指定して japanese-admins から市区町村境界の GeoJSON を取得する
+ * @param adminCode 市区町村コード（5桁、例: '01101'）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ *
+ * @example
+ * const sapporoChuoku = await fetchMunicipalityGeojson('01101'); // 札幌市中央区の境界を取得
+ */
+export async function fetchMunicipalityGeojson(
+  adminCode: string
+): Promise<GeoJSON.FeatureCollection | null> {
+  const url = buildJapaneseAdminsUrl(adminCode);
+  const data = await fetchJson(url);
+  return data;
+}

--- a/src/utils/japaneseAdminsUtils.ts
+++ b/src/utils/japaneseAdminsUtils.ts
@@ -3,6 +3,40 @@ import { fetchJson } from './fetchJson';
 const JAPANESE_ADMINS_BASE_URL = 'https://geolonia.github.io/japanese-admins';
 
 /**
+ * 都道府県コード（2桁）のバリデーション
+ * @param code 都道府県コード
+ * @returns バリデーション結果
+ */
+function validatePrefectureCode(code: string): boolean {
+  return /^\d{2}$/.test(code);
+}
+
+/**
+ * 市区町村コード（5桁）のバリデーション
+ * @param code 市区町村コード
+ * @returns バリデーション結果
+ */
+function validateMunicipalityCode(code: string): boolean {
+  return /^\d{5}$/.test(code);
+}
+
+/**
+ * GeoJSON.FeatureCollection の型ガード
+ * @param data チェック対象のデータ
+ * @returns FeatureCollection かどうか
+ */
+function isFeatureCollection(data: unknown): data is GeoJSON.FeatureCollection {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    data.type === 'FeatureCollection' &&
+    'features' in data &&
+    Array.isArray((data as { features: unknown }).features)
+  );
+}
+
+/**
  * 都道府県コードまたは市区町村コードから japanese-admins の GeoJSON URL を生成する
  * @param code 都道府県コード（2桁）または市区町村コード（5桁）
  * @returns GeoJSON の URL
@@ -19,7 +53,7 @@ export function buildJapaneseAdminsUrl(code: string): string {
 /**
  * 都道府県コードを指定して japanese-admins から都道府県境界の GeoJSON を取得する
  * @param prefCode 都道府県コード（2桁、例: '01'）
- * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時・バリデーションエラー時）
  *
  * @example
  * const hokkaido = await fetchPrefectureGeojson('01'); // 北海道の境界を取得
@@ -27,15 +61,22 @@ export function buildJapaneseAdminsUrl(code: string): string {
 export async function fetchPrefectureGeojson(
   prefCode: string
 ): Promise<GeoJSON.FeatureCollection | null> {
+  // 入力バリデーション
+  if (!validatePrefectureCode(prefCode)) {
+    return null;
+  }
+
   const url = buildJapaneseAdminsUrl(prefCode);
   const data = await fetchJson(url);
-  return data;
+
+  // FeatureCollection の型チェック
+  return isFeatureCollection(data) ? data : null;
 }
 
 /**
  * 市区町村コードを指定して japanese-admins から市区町村境界の GeoJSON を取得する
  * @param adminCode 市区町村コード（5桁、例: '01101'）
- * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時）
+ * @returns Promise<GeoJSON.FeatureCollection | null> GeoJSON または null（取得失敗時・バリデーションエラー時）
  *
  * @example
  * const sapporoChuoku = await fetchMunicipalityGeojson('01101'); // 札幌市中央区の境界を取得
@@ -43,7 +84,14 @@ export async function fetchPrefectureGeojson(
 export async function fetchMunicipalityGeojson(
   adminCode: string
 ): Promise<GeoJSON.FeatureCollection | null> {
+  // 入力バリデーション
+  if (!validateMunicipalityCode(adminCode)) {
+    return null;
+  }
+
   const url = buildJapaneseAdminsUrl(adminCode);
   const data = await fetchJson(url);
-  return data;
+
+  // FeatureCollection の型チェック
+  return isFeatureCollection(data) ? data : null;
 }

--- a/tests/japaneseAdminsUtils.test.ts
+++ b/tests/japaneseAdminsUtils.test.ts
@@ -58,6 +58,51 @@ describe('japaneseAdminsUtils', () => {
       const result = await fetchPrefectureGeojson('99');
       expect(result).toBeNull();
     });
+
+    // 境界ケース: 不正なコード形式
+    it('1桁のコードは null を返す', async () => {
+      const result = await fetchPrefectureGeojson('1');
+      expect(result).toBeNull();
+      expect(mockedFetchJson).not.toHaveBeenCalled();
+    });
+
+    it('3桁以上のコードは null を返す', async () => {
+      const result = await fetchPrefectureGeojson('012');
+      expect(result).toBeNull();
+      expect(mockedFetchJson).not.toHaveBeenCalled();
+    });
+
+    it('非数字のコードは null を返す', async () => {
+      const result = await fetchPrefectureGeojson('ab');
+      expect(result).toBeNull();
+      expect(mockedFetchJson).not.toHaveBeenCalled();
+    });
+
+    // 境界ケース: FeatureCollection 以外が返る場合
+    it('FeatureCollection 以外の JSON が返る場合は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce({ foo: 'bar' });
+      const result = await fetchPrefectureGeojson('01');
+      expect(result).toBeNull();
+    });
+
+    it('Feature 単体が返る場合は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      });
+      const result = await fetchPrefectureGeojson('01');
+      expect(result).toBeNull();
+    });
+
+    it('type が FeatureCollection だが features が配列でない場合は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce({
+        type: 'FeatureCollection',
+        features: 'not an array',
+      });
+      const result = await fetchPrefectureGeojson('01');
+      expect(result).toBeNull();
+    });
   });
 
   describe('fetchMunicipalityGeojson', () => {
@@ -82,6 +127,51 @@ describe('japaneseAdminsUtils', () => {
     it('取得失敗時は null を返す', async () => {
       mockedFetchJson.mockResolvedValueOnce(null);
       const result = await fetchMunicipalityGeojson('99999');
+      expect(result).toBeNull();
+    });
+
+    // 境界ケース: 不正なコード形式
+    it('4桁のコードは null を返す', async () => {
+      const result = await fetchMunicipalityGeojson('0110');
+      expect(result).toBeNull();
+      expect(mockedFetchJson).not.toHaveBeenCalled();
+    });
+
+    it('6桁以上のコードは null を返す', async () => {
+      const result = await fetchMunicipalityGeojson('011011');
+      expect(result).toBeNull();
+      expect(mockedFetchJson).not.toHaveBeenCalled();
+    });
+
+    it('非数字のコードは null を返す', async () => {
+      const result = await fetchMunicipalityGeojson('abcde');
+      expect(result).toBeNull();
+      expect(mockedFetchJson).not.toHaveBeenCalled();
+    });
+
+    // 境界ケース: FeatureCollection 以外が返る場合
+    it('FeatureCollection 以外の JSON が返る場合は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce({ foo: 'bar' });
+      const result = await fetchMunicipalityGeojson('01101');
+      expect(result).toBeNull();
+    });
+
+    it('Feature 単体が返る場合は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      });
+      const result = await fetchMunicipalityGeojson('01101');
+      expect(result).toBeNull();
+    });
+
+    it('type が FeatureCollection だが features が配列でない場合は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce({
+        type: 'FeatureCollection',
+        features: 'not an array',
+      });
+      const result = await fetchMunicipalityGeojson('01101');
       expect(result).toBeNull();
     });
   });

--- a/tests/japaneseAdminsUtils.test.ts
+++ b/tests/japaneseAdminsUtils.test.ts
@@ -1,0 +1,88 @@
+import {
+  buildJapaneseAdminsUrl,
+  fetchPrefectureGeojson,
+  fetchMunicipalityGeojson,
+} from '../src/utils/japaneseAdminsUtils';
+
+// fetchJson をモック
+jest.mock('../src/utils/fetchJson', () => ({
+  fetchJson: jest.fn(),
+}));
+
+import { fetchJson } from '../src/utils/fetchJson';
+const mockedFetchJson = fetchJson as jest.MockedFunction<typeof fetchJson>;
+
+describe('japaneseAdminsUtils', () => {
+  beforeEach(() => {
+    mockedFetchJson.mockReset();
+  });
+
+  describe('buildJapaneseAdminsUrl', () => {
+    it('都道府県コード（2桁）でURLを生成する', () => {
+      const url = buildJapaneseAdminsUrl('01');
+      expect(url).toBe('https://geolonia.github.io/japanese-admins/01/01.json');
+    });
+
+    it('市区町村コード（5桁）でURLを生成する', () => {
+      const url = buildJapaneseAdminsUrl('01101');
+      expect(url).toBe('https://geolonia.github.io/japanese-admins/01/01101.json');
+    });
+
+    it('47都道府県のURLを生成する', () => {
+      const url = buildJapaneseAdminsUrl('47');
+      expect(url).toBe('https://geolonia.github.io/japanese-admins/47/47.json');
+    });
+  });
+
+  describe('fetchPrefectureGeojson', () => {
+    const mockGeojson = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]] },
+          properties: { name: '北海道' },
+        },
+      ],
+    };
+
+    it('都道府県コードを指定してGeoJSONを取得する', async () => {
+      mockedFetchJson.mockResolvedValueOnce(mockGeojson);
+      const result = await fetchPrefectureGeojson('01');
+      expect(result).toEqual(mockGeojson);
+      expect(mockedFetchJson).toHaveBeenCalledWith('https://geolonia.github.io/japanese-admins/01/01.json');
+    });
+
+    it('取得失敗時は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce(null);
+      const result = await fetchPrefectureGeojson('99');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('fetchMunicipalityGeojson', () => {
+    const mockGeojson = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Polygon', coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]] },
+          properties: { name: '札幌市中央区' },
+        },
+      ],
+    };
+
+    it('市区町村コードを指定してGeoJSONを取得する', async () => {
+      mockedFetchJson.mockResolvedValueOnce(mockGeojson);
+      const result = await fetchMunicipalityGeojson('01101');
+      expect(result).toEqual(mockGeojson);
+      expect(mockedFetchJson).toHaveBeenCalledWith('https://geolonia.github.io/japanese-admins/01/01101.json');
+    });
+
+    it('取得失敗時は null を返す', async () => {
+      mockedFetchJson.mockResolvedValueOnce(null);
+      const result = await fetchMunicipalityGeojson('99999');
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## 概要

都道府県コード・市区町村コードを指定して Geolonia の japanese-admins リポジトリから境界データ（GeoJSON）を取得する機能を実装したってばよ！

Closes #99

## 実装内容

### 追加した関数

#### `buildJapaneseAdminsUrl(code: string): string`
都道府県コード（2桁）または市区町村コード（5桁）から japanese-admins の GeoJSON URL を生成する関数だってばよ。

```typescript
buildJapaneseAdminsUrl('01')      // => 'https://geolonia.github.io/japanese-admins/01/01.json'
buildJapaneseAdminsUrl('01101')   // => 'https://geolonia.github.io/japanese-admins/01/01101.json'
```

#### `fetchPrefectureGeojson(prefCode: string): Promise<GeoJSON.FeatureCollection | null>`
都道府県コードを指定して都道府県境界の GeoJSON を取得する関数だってばよ。

```typescript
const hokkaido = await fetchPrefectureGeojson('01'); // 北海道の境界を取得
```

#### `fetchMunicipalityGeojson(adminCode: string): Promise<GeoJSON.FeatureCollection | null>`
市区町村コードを指定して市区町村境界の GeoJSON を取得する関数だってばよ。

```typescript
const sapporoChuoku = await fetchMunicipalityGeojson('01101'); // 札幌市中央区の境界を取得
```

### エラーハンドリング

- 存在しないコードを指定した場合は `null` を返すってばよ
- ネットワークエラー時も `null` を返すってばよ
- 既存の `fetchJson` ユーティリティを活用してエラーハンドリングを実装してるってばよ

### ファイル構成

- `src/utils/japaneseAdminsUtils.ts` - 実装ファイル
- `tests/japaneseAdminsUtils.test.ts` - テストファイル（TDD で実装前に作成）
- `docs/utils/japaneseAdminsUtils.d.ts` - 型定義ファイル（ビルドで自動生成）

## テスト

### テストケース（7件）

✅ **buildJapaneseAdminsUrl**
- 都道府県コード（2桁）でURLを生成する
- 市区町村コード（5桁）でURLを生成する
- 47都道府県のURLを生成する

✅ **fetchPrefectureGeojson**
- 都道府県コードを指定してGeoJSONを取得する
- 取得失敗時は null を返す

✅ **fetchMunicipalityGeojson**
- 市区町村コードを指定してGeoJSONを取得する
- 取得失敗時は null を返す

### テスト結果

```
PASS tests/japaneseAdminsUtils.test.ts
  japaneseAdminsUtils
    buildJapaneseAdminsUrl
      ✓ 都道府県コード（2桁）でURLを生成する
      ✓ 市区町村コード（5桁）でURLを生成する
      ✓ 47都道府県のURLを生成する
    fetchPrefectureGeojson
      ✓ 都道府県コードを指定してGeoJSONを取得する
      ✓ 取得失敗時は null を返す
    fetchMunicipalityGeojson
      ✓ 市区町村コードを指定してGeoJSONを取得する
      ✓ 取得失敗時は null を返す

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
```

### 全テスト結果

```
Test Suites: 38 passed, 38 total
Tests:       189 passed, 189 total
```

## 完了条件チェック

- ✅ 都道府県コード（例: `01`）を指定して境界 GeoJSON を取得できる
- ✅ 市区町村コード（例: `01101`）を指定して境界 GeoJSON を取得できる
- ✅ 存在しないコードを指定した場合に適切にエラーハンドリングされる
- ✅ ユニットテストがパスしている

## 設計方針

### TDD（テスト駆動開発）

issue #99 の要件に従い、実装前にテストを作成してから実装したってばよ。

### 既存コードの活用

- `fetchJson` - URL から JSON を取得する汎用関数を活用
- `geojsonUtils` - GeoJSON のパース・検証関数（将来的に活用可能）

### 既存実装との分離

`nationalLandNumericalInformationUtils.ts` はベクタータイル（.pbf）を扱うのに対し、japanese-admins は GeoJSON を扱うため、別ファイルとして実装したってばよ。

## ビルド確認

✅ ビルド成功
✅ 型定義ファイル自動生成

## 参考

- japanese-admins リポジトリ: https://github.com/geolonia/japanese-admins
- エンドポイント形式: `https://geolonia.github.io/japanese-admins/<prefCode>/<code>.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 日本の都道府県・市町村境界のGeoJSONを取得するユーティリティを追加しました。入力コードの形式チェックと取得結果の妥当性検証を行います。

* **Tests**
  * URL生成と取得・検証の動作を確認するテストを追加しました。無効入力や想定外のレスポンス時の挙動も網羅しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->