### PR TITLE
feat: 座標移動ユーティリティ getMovedCoordinate を追加 (#108)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { setFillStyle as applyFillStyle, FillStyleOptions } from './setFillStyle
 import { setLineStyle, LineStyleOptions } from './utils/lineStyleUtils';
 import { baseMapStyleUrl } from './utils/baseMapStyleUtils';
 import { fetchTottoriDataIndex, addTottoriDataSource, addTottoriDataLayer, removeTottoriDataLayer, TottoriDataEntry } from './utils/tottoriDataUtils';
-import { nearestPointOnSegment, nearestPointOnLine, bearingBetweenPoints, distanceBetweenPoints, collectLineFeatures } from './utils/geometryUtils';
+import { nearestPointOnSegment, nearestPointOnLine, bearingBetweenPoints, distanceBetweenPoints, collectLineFeatures, getMovedCoordinate } from './utils/geometryUtils';
 
 declare global {
   interface Window {
@@ -794,4 +794,5 @@ window.geolonia.japan.geometry = {
   bearingBetweenPoints,
   distanceBetweenPoints,
   collectLineFeatures,
+  getMovedCoordinate,
 };

--- a/src/utils/geometryUtils.ts
+++ b/src/utils/geometryUtils.ts
@@ -195,3 +195,37 @@ export const collectLineFeatures = (
 
   return lines;
 };
+
+/**
+ * 指定座標から方向（度）・距離（メートル）で移動した新座標を計算する。
+ * ハバーサイン公式の逆計算（destination point）。
+ * @param center 始点座標 [lng, lat]
+ * @param direction 方位角（度、北=0, 東=90, 南=180, 西=270）
+ * @param distance 移動距離（メートル）
+ * @returns 移動後の座標 [lng, lat]
+ */
+export const getMovedCoordinate = (
+  center: [number, number],
+  direction: number,
+  distance: number,
+): [number, number] => {
+  const R = 6378137; // 地球の赤道半径 (m)
+  const lat1 = (center[1] * Math.PI) / 180;
+  const lng1 = (center[0] * Math.PI) / 180;
+  const bearing = (direction * Math.PI) / 180;
+  const angularDistance = distance / R;
+
+  const lat2 = Math.asin(
+    Math.sin(lat1) * Math.cos(angularDistance) +
+    Math.cos(lat1) * Math.sin(angularDistance) * Math.cos(bearing),
+  );
+
+  const lng2 =
+    lng1 +
+    Math.atan2(
+      Math.sin(bearing) * Math.sin(angularDistance) * Math.cos(lat1),
+      Math.cos(angularDistance) - Math.sin(lat1) * Math.sin(lat2),
+    );
+
+  return [(lng2 * 180) / Math.PI, (lat2 * 180) / Math.PI];
+};

--- a/tests/geometryUtils.test.ts
+++ b/tests/geometryUtils.test.ts
@@ -4,6 +4,7 @@ import {
   bearingBetweenPoints,
   distanceBetweenPoints,
   collectLineFeatures,
+  getMovedCoordinate,
 } from '../src/utils/geometryUtils';
 
 describe('nearestPointOnSegment', () => {
@@ -229,5 +230,58 @@ describe('collectLineFeatures', () => {
     };
     const result = collectLineFeatures(geojson as any);
     expect(result).toHaveLength(1);
+  });
+});
+
+describe('getMovedCoordinate', () => {
+  it('真北に1km移動すると緯度が増加し経度は変わらない', () => {
+    const center: [number, number] = [139.6917, 35.6895]; // 東京
+    const result = getMovedCoordinate(center, 0, 1000);
+    expect(result[0]).toBeCloseTo(139.6917, 3); // 経度はほぼ変わらない
+    expect(result[1]).toBeGreaterThan(35.6895); // 緯度が増加
+    // 1kmの移動は約0.009度
+    const latDiff = result[1] - 35.6895;
+    expect(latDiff).toBeCloseTo(0.009, 2);
+  });
+
+  it('真東に1km移動すると経度が増加し緯度はほぼ変わらない', () => {
+    const center: [number, number] = [139.6917, 35.6895];
+    const result = getMovedCoordinate(center, 90, 1000);
+    expect(result[0]).toBeGreaterThan(139.6917); // 経度が増加
+    expect(result[1]).toBeCloseTo(35.6895, 3); // 緯度はほぼ変わらない
+  });
+
+  it('真南に1km移動すると緯度が減少する', () => {
+    const center: [number, number] = [139.6917, 35.6895];
+    const result = getMovedCoordinate(center, 180, 1000);
+    expect(result[0]).toBeCloseTo(139.6917, 3);
+    expect(result[1]).toBeLessThan(35.6895);
+  });
+
+  it('真西に1km移動すると経度が減少する', () => {
+    const center: [number, number] = [139.6917, 35.6895];
+    const result = getMovedCoordinate(center, 270, 1000);
+    expect(result[0]).toBeLessThan(139.6917);
+    expect(result[1]).toBeCloseTo(35.6895, 3);
+  });
+
+  it('距離0で移動すると同じ座標を返す', () => {
+    const center: [number, number] = [139.6917, 35.6895];
+    const result = getMovedCoordinate(center, 45, 0);
+    expect(result[0]).toBeCloseTo(139.6917, 10);
+    expect(result[1]).toBeCloseTo(35.6895, 10);
+  });
+
+  it('bearingBetweenPoints と distanceBetweenPoints の逆演算として整合する', () => {
+    const from: [number, number] = [139.6917, 35.6895];
+    const direction = 45;
+    const distance = 5000; // 5km
+    const to = getMovedCoordinate(from, direction, distance);
+    // 移動後の距離を検証
+    const calcDist = distanceBetweenPoints(from, to);
+    expect(calcDist).toBeCloseTo(distance, -1); // 1m精度
+    // 移動後の方位角を検証
+    const calcBearing = bearingBetweenPoints(from, to);
+    expect(calcBearing).toBeCloseTo(direction, 0);
   });
 });


### PR DESCRIPTION
## Summary
- scratch の `geoloniaMapMoveControl/utils.js` にある座標移動ロジックを SDK に移植
- `getMovedCoordinate(center, direction, distance)`: 方位角（度）・距離（メートル）で新座標を計算するハバーサイン逆計算関数を `geometryUtils.ts` に追加
- `window.geolonia.japan.geometry` からもアクセス可能

## Functional Verification Criteria
- 北/東/南/西 各方向への1km移動で正しい座標が得られる
- 距離0の移動で元の座標が返る
- `bearingBetweenPoints` / `distanceBetweenPoints` の逆演算として整合する

## Review Criteria
- ハバーサイン公式の逆計算が正しく実装されている
- 既存の `bearingBetweenPoints` / `distanceBetweenPoints` と定数（地球半径）が統一されている
- TypeScript の型定義が適切
- テストカバレッジが十分（6テストケース）

closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 幾何ユーティリティに新しい座標計算機能を追加しました。中心座標から方位角（度）と距離（メートル）を指定することで、移動後の座標を計算できます。

* **テスト**
  * 新機能の複数方向移動パターンを含む包括的なテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/japan-cityos-sdk/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->