### PR TITLE
feat: パス補間ユーティリティ pathUtils を追加 (#106)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { setLineStyle, LineStyleOptions } from './utils/lineStyleUtils';
 import { baseMapStyleUrl } from './utils/baseMapStyleUtils';
 import { fetchTottoriDataIndex, addTottoriDataSource, addTottoriDataLayer, removeTottoriDataLayer, TottoriDataEntry } from './utils/tottoriDataUtils';
 import { nearestPointOnSegment, nearestPointOnLine, bearingBetweenPoints, distanceBetweenPoints, collectLineFeatures } from './utils/geometryUtils';
+import { extractLineCoordinates, hasLineGeometry, calculatePathDistance, interpolateAlongPath, buildVertexTimings } from './utils/pathUtils';
 
 declare global {
   interface Window {
@@ -794,4 +795,9 @@ window.geolonia.japan.geometry = {
   bearingBetweenPoints,
   distanceBetweenPoints,
   collectLineFeatures,
+  extractLineCoordinates,
+  hasLineGeometry,
+  calculatePathDistance,
+  interpolateAlongPath,
+  buildVertexTimings,
 };

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -55,6 +55,11 @@ export const extractLineCoordinates = (
         lines.push(coords);
       }
     }
+  } else if (geojson.type === 'GeometryCollection') {
+    for (const geometry of geojson.geometries) {
+      if (!geometry) continue;
+      lines.push(...extractLineCoordinates(geometry));
+    }
   }
 
   return lines;
@@ -71,6 +76,18 @@ export const hasLineGeometry = (geojson: GeoJSON.GeoJSON): boolean => {
 };
 
 /**
+ * 座標を [lng, lat] として検証する。
+ * 距離計算に NaN を持ち込まないよう、有限な数値2つを持つものだけ通す。
+ */
+const toLngLat = (coord: unknown): [number, number] | null => {
+  if (!Array.isArray(coord) || coord.length < 2) return null;
+  const [lng, lat] = coord;
+  if (typeof lng !== 'number' || typeof lat !== 'number') return null;
+  if (!Number.isFinite(lng) || !Number.isFinite(lat)) return null;
+  return [lng, lat];
+};
+
+/**
  * パス全体の総距離をメートルで計算する（ハバーサイン公式）。
  * @param coords 座標配列 [[lng, lat], ...]
  * @returns 総距離（メートル）。座標が2点未満の場合は 0
@@ -80,8 +97,9 @@ export const calculatePathDistance = (coords: number[][]): number => {
 
   let totalDistance = 0;
   for (let i = 0; i < coords.length - 1; i++) {
-    const from: [number, number] = [coords[i][0], coords[i][1]];
-    const to: [number, number] = [coords[i + 1][0], coords[i + 1][1]];
+    const from = toLngLat(coords[i]);
+    const to = toLngLat(coords[i + 1]);
+    if (!from || !to) continue;
     totalDistance += distanceBetweenPoints(from, to);
   }
 
@@ -104,15 +122,16 @@ export const interpolateAlongPath = (
   const totalDistance = calculatePathDistance(coords);
   if (totalDistance === 0) {
     // すべての点が同一座標の場合、最初の点を返す
-    return [coords[0][0], coords[0][1]];
+    return toLngLat(coords[0]);
   }
 
   const targetDistance = totalDistance * ratio;
   let cumulativeDistance = 0;
 
   for (let i = 0; i < coords.length - 1; i++) {
-    const from: [number, number] = [coords[i][0], coords[i][1]];
-    const to: [number, number] = [coords[i + 1][0], coords[i + 1][1]];
+    const from = toLngLat(coords[i]);
+    const to = toLngLat(coords[i + 1]);
+    if (!from || !to) continue;
     const segmentDistance = distanceBetweenPoints(from, to);
 
     if (cumulativeDistance + segmentDistance >= targetDistance) {
@@ -131,8 +150,11 @@ export const interpolateAlongPath = (
   }
 
   // ratio = 1.0 の場合、最終点を返す
-  const lastCoord = coords[coords.length - 1];
-  return [lastCoord[0], lastCoord[1]];
+  for (let i = coords.length - 1; i >= 0; i--) {
+    const last = toLngLat(coords[i]);
+    if (last) return last;
+  }
+  return null;
 };
 
 /**
@@ -158,9 +180,11 @@ export const buildVertexTimings = (coords: number[][]): VertexTiming[] => {
     });
 
     if (i < coords.length - 1) {
-      const from: [number, number] = [coords[i][0], coords[i][1]];
-      const to: [number, number] = [coords[i + 1][0], coords[i + 1][1]];
-      cumulativeDistance += distanceBetweenPoints(from, to);
+      const from = toLngLat(coords[i]);
+      const to = toLngLat(coords[i + 1]);
+      if (from && to) {
+        cumulativeDistance += distanceBetweenPoints(from, to);
+      }
     }
   }
 

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -1,0 +1,168 @@
+/**
+ * パス補間・距離計算ユーティリティ
+ *
+ * scratch (chizubouken-lab-scratch) の path-utils.js から移植。
+ * パス上の座標補間やアニメーション用の時間計算を提供。
+ */
+
+import { distanceBetweenPoints } from './geometryUtils';
+
+/** buildVertexTimings の戻り値の要素 */
+export interface VertexTiming {
+  /** 頂点のインデックス */
+  index: number;
+  /** 始点からこの頂点までの累積距離（メートル） */
+  cumulativeDistance: number;
+  /** パス全体に対するこの頂点の距離比率 (0〜1) */
+  ratio: number;
+}
+
+/**
+ * GeoJSON から LineString/MultiLineString の座標配列を抽出する。
+ * @param geojson GeoJSON オブジェクト（Feature, FeatureCollection, Geometry）
+ * @returns 座標配列 [[lng, lat], ...] の配列。線が見つからない場合は空配列
+ */
+export const extractLineCoordinates = (
+  geojson: GeoJSON.GeoJSON,
+): number[][][] => {
+  if (!geojson) return [];
+
+  const lines: number[][][] = [];
+
+  // FeatureCollection の場合
+  if (geojson.type === 'FeatureCollection') {
+    for (const feature of geojson.features) {
+      if (!feature || !feature.geometry) continue;
+      lines.push(...extractLineCoordinates(feature.geometry));
+    }
+    return lines;
+  }
+
+  // Feature の場合
+  if (geojson.type === 'Feature') {
+    if (!geojson.geometry) return [];
+    return extractLineCoordinates(geojson.geometry);
+  }
+
+  // Geometry の場合
+  if (geojson.type === 'LineString') {
+    if (Array.isArray(geojson.coordinates) && geojson.coordinates.length >= 2) {
+      lines.push(geojson.coordinates);
+    }
+  } else if (geojson.type === 'MultiLineString') {
+    for (const coords of geojson.coordinates) {
+      if (Array.isArray(coords) && coords.length >= 2) {
+        lines.push(coords);
+      }
+    }
+  }
+
+  return lines;
+};
+
+/**
+ * GeoJSON が線ジオメトリ（LineString/MultiLineString）を含むか判定する。
+ * @param geojson GeoJSON オブジェクト
+ * @returns 線ジオメトリが1つ以上含まれている場合 true
+ */
+export const hasLineGeometry = (geojson: GeoJSON.GeoJSON): boolean => {
+  const lines = extractLineCoordinates(geojson);
+  return lines.length > 0;
+};
+
+/**
+ * パス全体の総距離をメートルで計算する（ハバーサイン公式）。
+ * @param coords 座標配列 [[lng, lat], ...]
+ * @returns 総距離（メートル）。座標が2点未満の場合は 0
+ */
+export const calculatePathDistance = (coords: number[][]): number => {
+  if (!coords || coords.length < 2) return 0;
+
+  let totalDistance = 0;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const from: [number, number] = [coords[i][0], coords[i][1]];
+    const to: [number, number] = [coords[i + 1][0], coords[i + 1][1]];
+    totalDistance += distanceBetweenPoints(from, to);
+  }
+
+  return totalDistance;
+};
+
+/**
+ * パス上の指定割合（0〜1）の座標を線形補間で算出する。
+ * @param coords 座標配列 [[lng, lat], ...]
+ * @param ratio パス全体に対する割合 (0 = 始点, 1 = 終点)
+ * @returns 補間された座標 [lng, lat]。座標が2点未満または ratio が範囲外の場合は null
+ */
+export const interpolateAlongPath = (
+  coords: number[][],
+  ratio: number,
+): [number, number] | null => {
+  if (!coords || coords.length < 2) return null;
+  if (ratio < 0 || ratio > 1) return null;
+
+  const totalDistance = calculatePathDistance(coords);
+  if (totalDistance === 0) {
+    // すべての点が同一座標の場合、最初の点を返す
+    return [coords[0][0], coords[0][1]];
+  }
+
+  const targetDistance = totalDistance * ratio;
+  let cumulativeDistance = 0;
+
+  for (let i = 0; i < coords.length - 1; i++) {
+    const from: [number, number] = [coords[i][0], coords[i][1]];
+    const to: [number, number] = [coords[i + 1][0], coords[i + 1][1]];
+    const segmentDistance = distanceBetweenPoints(from, to);
+
+    if (cumulativeDistance + segmentDistance >= targetDistance) {
+      // 目標距離がこのセグメント内にある
+      const segmentRatio =
+        segmentDistance === 0
+          ? 0
+          : (targetDistance - cumulativeDistance) / segmentDistance;
+
+      const lng = from[0] + (to[0] - from[0]) * segmentRatio;
+      const lat = from[1] + (to[1] - from[1]) * segmentRatio;
+      return [lng, lat];
+    }
+
+    cumulativeDistance += segmentDistance;
+  }
+
+  // ratio = 1.0 の場合、最終点を返す
+  const lastCoord = coords[coords.length - 1];
+  return [lastCoord[0], lastCoord[1]];
+};
+
+/**
+ * 各頂点への移動時間を距離比率で計算する（アニメーション用）。
+ * @param coords 座標配列 [[lng, lat], ...]
+ * @returns 各頂点の累積距離と比率の配列。座標が2点未満の場合は空配列
+ */
+export const buildVertexTimings = (coords: number[][]): VertexTiming[] => {
+  if (!coords || coords.length < 2) return [];
+
+  const totalDistance = calculatePathDistance(coords);
+  const timings: VertexTiming[] = [];
+
+  let cumulativeDistance = 0;
+
+  for (let i = 0; i < coords.length; i++) {
+    const ratio = totalDistance === 0 ? 0 : cumulativeDistance / totalDistance;
+
+    timings.push({
+      index: i,
+      cumulativeDistance,
+      ratio,
+    });
+
+    if (i < coords.length - 1) {
+      const from: [number, number] = [coords[i][0], coords[i][1]];
+      const to: [number, number] = [coords[i + 1][0], coords[i + 1][1]];
+      cumulativeDistance += distanceBetweenPoints(from, to);
+    }
+  }
+
+  return timings;
+};

--- a/tests/pathUtils.test.ts
+++ b/tests/pathUtils.test.ts
@@ -257,3 +257,71 @@ describe('buildVertexTimings', () => {
     }
   });
 });
+
+describe('GeometryCollection', () => {
+  const collection: GeoJSON.GeometryCollection = {
+    type: 'GeometryCollection',
+    geometries: [
+      { type: 'Point', coordinates: [139, 35] },
+      { type: 'LineString', coordinates: [[139, 35], [140, 36]] },
+      {
+        type: 'MultiLineString',
+        coordinates: [[[141, 37], [142, 38]], [[143, 39], [144, 40]]],
+      },
+    ],
+  };
+
+  it('GeometryCollection 内の線ジオメトリを抽出する', () => {
+    const result = extractLineCoordinates(collection);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual([[139, 35], [140, 36]]);
+  });
+
+  it('入れ子の GeometryCollection も再帰的に抽出する', () => {
+    const nested: GeoJSON.GeometryCollection = {
+      type: 'GeometryCollection',
+      geometries: [collection],
+    };
+    expect(extractLineCoordinates(nested)).toHaveLength(3);
+  });
+
+  it('線を含む GeometryCollection は hasLineGeometry が true', () => {
+    expect(hasLineGeometry(collection)).toBe(true);
+  });
+
+  it('線を含まない GeometryCollection は hasLineGeometry が false', () => {
+    const pointsOnly: GeoJSON.GeometryCollection = {
+      type: 'GeometryCollection',
+      geometries: [{ type: 'Point', coordinates: [139, 35] }],
+    };
+    expect(hasLineGeometry(pointsOnly)).toBe(false);
+  });
+});
+
+describe('不正な座標の扱い', () => {
+  const invalid = [[139, 35], [140]] as number[][];
+  const withNaN = [[139, 35], [NaN, 36], [141, 37]] as number[][];
+
+  it('要素が足りない座標は距離計算から除外する', () => {
+    expect(calculatePathDistance(invalid)).toBe(0);
+    expect(Number.isNaN(calculatePathDistance(withNaN))).toBe(false);
+  });
+
+  it('補間結果に NaN を返さない', () => {
+    // 有効なセグメントが1つも無い場合は、既存の「全点が同一座標」と同じく
+    // 最初の有効な点を返す。
+    expect(interpolateAlongPath(invalid, 0.5)).toEqual([139, 35]);
+    for (const point of [interpolateAlongPath(withNaN, 0.5), interpolateAlongPath(withNaN, 1)]) {
+      expect(point).not.toBeNull();
+      expect(Number.isNaN(point![0])).toBe(false);
+      expect(Number.isNaN(point![1])).toBe(false);
+    }
+  });
+
+  it('頂点タイミングに NaN を返さない', () => {
+    for (const t of buildVertexTimings(withNaN)) {
+      expect(Number.isNaN(t.ratio)).toBe(false);
+      expect(Number.isNaN(t.cumulativeDistance)).toBe(false);
+    }
+  });
+});

--- a/tests/pathUtils.test.ts
+++ b/tests/pathUtils.test.ts
@@ -1,0 +1,259 @@
+import {
+  extractLineCoordinates,
+  hasLineGeometry,
+  calculatePathDistance,
+  interpolateAlongPath,
+  buildVertexTimings,
+} from '../src/utils/pathUtils';
+
+describe('extractLineCoordinates', () => {
+  it('LineString Geometry から座標配列を抽出する', () => {
+    const geojson: GeoJSON.LineString = {
+      type: 'LineString',
+      coordinates: [[139, 35], [140, 36]],
+    };
+    const result = extractLineCoordinates(geojson);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual([[139, 35], [140, 36]]);
+  });
+
+  it('MultiLineString Geometry から複数の座標配列を抽出する', () => {
+    const geojson: GeoJSON.MultiLineString = {
+      type: 'MultiLineString',
+      coordinates: [
+        [[139, 35], [140, 36]],
+        [[141, 37], [142, 38]],
+      ],
+    };
+    const result = extractLineCoordinates(geojson);
+    expect(result).toHaveLength(2);
+  });
+
+  it('Feature から座標配列を抽出する', () => {
+    const geojson: GeoJSON.Feature = {
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [[139, 35], [140, 36]],
+      },
+      properties: {},
+    };
+    const result = extractLineCoordinates(geojson);
+    expect(result).toHaveLength(1);
+  });
+
+  it('FeatureCollection から座標配列を抽出する', () => {
+    const geojson: GeoJSON.FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: [[139, 35], [140, 36]],
+          },
+          properties: {},
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: [[141, 37], [142, 38]],
+          },
+          properties: {},
+        },
+      ],
+    };
+    const result = extractLineCoordinates(geojson);
+    expect(result).toHaveLength(2);
+  });
+
+  it('Point ジオメトリは無視する', () => {
+    const geojson: GeoJSON.Point = {
+      type: 'Point',
+      coordinates: [139, 35],
+    };
+    const result = extractLineCoordinates(geojson);
+    expect(result).toHaveLength(0);
+  });
+
+  it('座標が1点のみの LineString は無視する', () => {
+    const geojson: GeoJSON.LineString = {
+      type: 'LineString',
+      coordinates: [[139, 35]],
+    };
+    const result = extractLineCoordinates(geojson);
+    expect(result).toHaveLength(0);
+  });
+
+  it('null の場合は空配列を返す', () => {
+    expect(extractLineCoordinates(null as any)).toEqual([]);
+  });
+
+  it('Feature の geometry が null の場合は空配列を返す', () => {
+    const geojson: any = {
+      type: 'Feature',
+      geometry: null,
+      properties: {},
+    };
+    expect(extractLineCoordinates(geojson)).toEqual([]);
+  });
+
+  it('FeatureCollection 内の geometry が null のフィーチャーをスキップする', () => {
+    const geojson = {
+      type: 'FeatureCollection' as const,
+      features: [
+        { type: 'Feature' as const, geometry: null, properties: {} },
+        {
+          type: 'Feature' as const,
+          geometry: { type: 'LineString' as const, coordinates: [[139, 35], [140, 36]] },
+          properties: {},
+        },
+      ],
+    };
+    const result = extractLineCoordinates(geojson as any);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('hasLineGeometry', () => {
+  it('LineString を含む場合 true を返す', () => {
+    const geojson: GeoJSON.Feature = {
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: [[139, 35], [140, 36]] },
+      properties: {},
+    };
+    expect(hasLineGeometry(geojson)).toBe(true);
+  });
+
+  it('Point のみの場合 false を返す', () => {
+    const geojson: GeoJSON.Feature = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [139, 35] },
+      properties: {},
+    };
+    expect(hasLineGeometry(geojson)).toBe(false);
+  });
+});
+
+describe('calculatePathDistance', () => {
+  it('2点間のパス距離をメートルで計算する', () => {
+    // 東京（35.6762, 139.6503）→ 大阪（34.6937, 135.5023）: 約395km
+    const coords = [[139.6503, 35.6762], [135.5023, 34.6937]];
+    const dist = calculatePathDistance(coords);
+    expect(dist).toBeGreaterThan(380_000);
+    expect(dist).toBeLessThan(410_000);
+  });
+
+  it('3点のパス距離は各セグメントの合計', () => {
+    const coords = [[139, 35], [140, 35], [140, 36]];
+    const dist = calculatePathDistance(coords);
+    expect(dist).toBeGreaterThan(0);
+  });
+
+  it('座標が2点未満の場合は0を返す', () => {
+    expect(calculatePathDistance([[139, 35]])).toBe(0);
+    expect(calculatePathDistance([])).toBe(0);
+  });
+
+  it('null の場合は0を返す', () => {
+    expect(calculatePathDistance(null as any)).toBe(0);
+  });
+});
+
+describe('interpolateAlongPath', () => {
+  const coords = [[139, 35], [140, 35], [140, 36]];
+
+  it('ratio=0 で始点を返す', () => {
+    const result = interpolateAlongPath(coords, 0);
+    expect(result).not.toBeNull();
+    expect(result![0]).toBeCloseTo(139, 5);
+    expect(result![1]).toBeCloseTo(35, 5);
+  });
+
+  it('ratio=1 で終点を返す', () => {
+    const result = interpolateAlongPath(coords, 1);
+    expect(result).not.toBeNull();
+    expect(result![0]).toBeCloseTo(140, 5);
+    expect(result![1]).toBeCloseTo(36, 5);
+  });
+
+  it('ratio=0.5 で中間点を返す', () => {
+    const result = interpolateAlongPath(coords, 0.5);
+    expect(result).not.toBeNull();
+    // 中間は最初のセグメントの終点付近か2番目のセグメント上
+    expect(result![0]).toBeGreaterThanOrEqual(139);
+    expect(result![0]).toBeLessThanOrEqual(140);
+  });
+
+  it('ratio が負の場合は null を返す', () => {
+    expect(interpolateAlongPath(coords, -0.1)).toBeNull();
+  });
+
+  it('ratio が1を超える場合は null を返す', () => {
+    expect(interpolateAlongPath(coords, 1.1)).toBeNull();
+  });
+
+  it('座標が2点未満の場合は null を返す', () => {
+    expect(interpolateAlongPath([[139, 35]], 0.5)).toBeNull();
+  });
+
+  it('すべての点が同一座標の場合、最初の点を返す', () => {
+    const sameCoords = [[139, 35], [139, 35], [139, 35]];
+    const result = interpolateAlongPath(sameCoords, 0.5);
+    expect(result).not.toBeNull();
+    expect(result![0]).toBeCloseTo(139, 5);
+    expect(result![1]).toBeCloseTo(35, 5);
+  });
+});
+
+describe('buildVertexTimings', () => {
+  it('各頂点の累積距離と比率を返す', () => {
+    const coords = [[139, 35], [140, 35], [140, 36]];
+    const timings = buildVertexTimings(coords);
+    expect(timings).toHaveLength(3);
+
+    // 最初の頂点は ratio=0
+    expect(timings[0].index).toBe(0);
+    expect(timings[0].cumulativeDistance).toBe(0);
+    expect(timings[0].ratio).toBe(0);
+
+    // 中間の頂点
+    expect(timings[1].index).toBe(1);
+    expect(timings[1].cumulativeDistance).toBeGreaterThan(0);
+    expect(timings[1].ratio).toBeGreaterThan(0);
+    expect(timings[1].ratio).toBeLessThan(1);
+
+    // 最後の頂点は最終距離に近い比率
+    expect(timings[2].index).toBe(2);
+    expect(timings[2].ratio).toBeCloseTo(1, 1);
+  });
+
+  it('座標が2点未満の場合は空配列を返す', () => {
+    expect(buildVertexTimings([[139, 35]])).toEqual([]);
+    expect(buildVertexTimings([])).toEqual([]);
+  });
+
+  it('null の場合は空配列を返す', () => {
+    expect(buildVertexTimings(null as any)).toEqual([]);
+  });
+
+  it('すべての点が同一座標の場合、ratio はすべて0', () => {
+    const sameCoords = [[139, 35], [139, 35], [139, 35]];
+    const timings = buildVertexTimings(sameCoords);
+    expect(timings).toHaveLength(3);
+    timings.forEach(t => {
+      expect(t.ratio).toBe(0);
+      expect(t.cumulativeDistance).toBe(0);
+    });
+  });
+
+  it('比率は単調増加する', () => {
+    const coords = [[139, 35], [139.5, 35.5], [140, 36], [140.5, 36.5]];
+    const timings = buildVertexTimings(coords);
+    for (let i = 1; i < timings.length; i++) {
+      expect(timings[i].ratio).toBeGreaterThanOrEqual(timings[i - 1].ratio);
+      expect(timings[i].cumulativeDistance).toBeGreaterThanOrEqual(timings[i - 1].cumulativeDistance);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- scratch の `geoloniaMapMoveControl/path-utils.js` から5関数を TypeScript で SDK に移植
- `extractLineCoordinates`: GeoJSON (Feature/FeatureCollection/Geometry) から LineString/MultiLineString の座標配列を抽出
- `hasLineGeometry`: GeoJSON が線ジオメトリを含むか判定
- `calculatePathDistance`: パス総距離をメートルで計算（ハバーサイン公式）
- `interpolateAlongPath`: パス上の指定割合 (0〜1) の座標を線形補間で算出
- `buildVertexTimings`: 各頂点への累積距離・比率を計算（アニメーション用）
- `window.geolonia.japan.geometry` からアクセス可能
- `geometryUtils.distanceBetweenPoints` を内部利用し距離計算の重複を排除

## Functional Verification Criteria
- GeoJSON の各形式 (Geometry/Feature/FeatureCollection) から正しく座標を抽出できる
- 不正な入力 (null, 1点のみ等) に対して安全にハンドリングする
- ratio=0 で始点、ratio=1 で終点、ratio=0.5 で中間点を正しく返す
- buildVertexTimings の比率が単調増加する

## Review Criteria
- `distanceBetweenPoints` を再利用し、独自のハバーサイン計算を持たない
- GeoJSON の再帰的な走査が正しく実装されている
- エッジケース（同一座標、1点のみ等）のハンドリング
- 27テストケースでカバレッジ確保

closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GeoJSONの線ジオメトリや入れ子構造から路線座標を抽出できるようになりました。
  * パス距離の計算、線上の位置補間、頂点ごとのタイミング計算を公開APIで利用できます。

* **バグ修正**
  * 不正な座標や`NaN`を含むデータを安全に処理できるようになりました。

* **テスト**
  * 複雑なジオメトリ構造や不正な座標に対するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->