### PR TITLE
feat: 都道府県座標ユーティリティ prefectureUtils を追加 (#107)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { setLineStyle, LineStyleOptions } from './utils/lineStyleUtils';
 import { baseMapStyleUrl } from './utils/baseMapStyleUtils';
 import { fetchTottoriDataIndex, addTottoriDataSource, addTottoriDataLayer, removeTottoriDataLayer, TottoriDataEntry } from './utils/tottoriDataUtils';
 import { nearestPointOnSegment, nearestPointOnLine, bearingBetweenPoints, distanceBetweenPoints, collectLineFeatures } from './utils/geometryUtils';
+import { getPrefectureAnchor, buildPrefectureLineFeature, buildPrefectureLineLayerName, buildPrefectureLine, PREFECTURE_ANCHOR_CENTER, PREFECTURE_ANCHOR_CAPITAL } from './utils/prefectureUtils';
 
 declare global {
   interface Window {
@@ -794,4 +795,13 @@ window.geolonia.japan.geometry = {
   bearingBetweenPoints,
   distanceBetweenPoints,
   collectLineFeatures,
+};
+
+window.geolonia.japan.prefecture = {
+  getPrefectureAnchor,
+  buildPrefectureLineFeature,
+  buildPrefectureLineLayerName,
+  buildPrefectureLine,
+  PREFECTURE_ANCHOR_CENTER,
+  PREFECTURE_ANCHOR_CAPITAL,
 };

--- a/src/utils/prefectureUtils.ts
+++ b/src/utils/prefectureUtils.ts
@@ -17,6 +17,61 @@ export const PREFECTURE_ANCHOR_CAPITAL = 'capital';
 export type PrefectureAnchor = typeof PREFECTURE_ANCHOR_CENTER | typeof PREFECTURE_ANCHOR_CAPITAL;
 
 /**
+ * 都道府県 → 県庁所在地（東京都は都庁所在地の新宿区）。
+ * 都道府県名からの機械的な導出では「北海道→札幌市」「愛知県→名古屋市」の
+ * ように一致しない県が多いため、明示的に持つ。
+ */
+const PREFECTURE_CAPITALS: Record<string, string> = {
+  '北海道': '札幌市',
+  '青森県': '青森市',
+  '岩手県': '盛岡市',
+  '宮城県': '仙台市',
+  '秋田県': '秋田市',
+  '山形県': '山形市',
+  '福島県': '福島市',
+  '茨城県': '水戸市',
+  '栃木県': '宇都宮市',
+  '群馬県': '前橋市',
+  '埼玉県': 'さいたま市',
+  '千葉県': '千葉市',
+  '東京都': '新宿区',
+  '神奈川県': '横浜市',
+  '新潟県': '新潟市',
+  '富山県': '富山市',
+  '石川県': '金沢市',
+  '福井県': '福井市',
+  '山梨県': '甲府市',
+  '長野県': '長野市',
+  '岐阜県': '岐阜市',
+  '静岡県': '静岡市',
+  '愛知県': '名古屋市',
+  '三重県': '津市',
+  '滋賀県': '大津市',
+  '京都府': '京都市',
+  '大阪府': '大阪市',
+  '兵庫県': '神戸市',
+  '奈良県': '奈良市',
+  '和歌山県': '和歌山市',
+  '鳥取県': '鳥取市',
+  '島根県': '松江市',
+  '岡山県': '岡山市',
+  '広島県': '広島市',
+  '山口県': '山口市',
+  '徳島県': '徳島市',
+  '香川県': '高松市',
+  '愛媛県': '松山市',
+  '高知県': '高知市',
+  '福岡県': '福岡市',
+  '佐賀県': '佐賀市',
+  '長崎県': '長崎市',
+  '熊本県': '熊本市',
+  '大分県': '大分市',
+  '宮崎県': '宮崎市',
+  '鹿児島県': '鹿児島市',
+  '沖縄県': '那覇市',
+};
+
+/**
  * 都道府県名からアンカー座標（中心 or 県庁所在地）を取得する。
  * @param prefName 都道府県名（例: "東京都", "北海道"）
  * @param anchor アンカー種別（"center" または "capital"、デフォルト: "center"）
@@ -37,13 +92,15 @@ export const getPrefectureAnchor = async (
 
     // アンカー種別に応じて座標を取得
     if (anchor === PREFECTURE_ANCHOR_CAPITAL) {
-      // 県庁所在地の座標を取得
-      // 都道府県名 + "県庁所在地" で住所正規化を試みる
-      const capitalName = result.pref === '東京都' ? '東京' : result.pref.replace(/[都道府県]$/, '');
-      const capitalResult = await normalize(`${result.pref}${capitalName}`);
+      const capitalName = PREFECTURE_CAPITALS[result.pref];
+      if (capitalName) {
+        const capitalResult = await normalize(`${result.pref}${capitalName}`);
 
-      if (capitalResult && capitalResult.point && capitalResult.point.lat && capitalResult.point.lng) {
-        return [capitalResult.point.lng, capitalResult.point.lat];
+        if (capitalResult && capitalResult.point && capitalResult.point.lat && capitalResult.point.lng) {
+          return [capitalResult.point.lng, capitalResult.point.lat];
+        }
+      } else {
+        console.warn(`都道府県 "${result.pref}" の県庁所在地が不明です`);
       }
     }
 
@@ -102,9 +159,9 @@ export const buildPrefectureLineLayerName = (
   prefTo: string,
   pointTo: PrefectureAnchor,
 ): string => {
-  // 都道府県名を正規化（都道府県を除去）
+  // 末尾の「都・府・県」のみを取り除く（「北海道」は道までが名称）
   const normalizePrefix = (name: string) => {
-    return name.replace(/[都道府県]/g, '').toLowerCase();
+    return name.replace(/(都|府|県)$/u, '').toLowerCase();
   };
 
   const from = normalizePrefix(prefFrom);

--- a/src/utils/prefectureUtils.ts
+++ b/src/utils/prefectureUtils.ts
@@ -1,0 +1,150 @@
+/**
+ * 都道府県座標ユーティリティ
+ *
+ * scratch (chizubouken-lab-scratch) の prefecture-anchor.js および
+ * draw-prefecture-line.js から移植。
+ */
+
+import { normalize } from '@geolonia/normalize-japanese-addresses';
+
+/** アンカー種別: 中心座標 */
+export const PREFECTURE_ANCHOR_CENTER = 'center';
+
+/** アンカー種別: 県庁所在地 */
+export const PREFECTURE_ANCHOR_CAPITAL = 'capital';
+
+/** アンカー種別 */
+export type PrefectureAnchor = typeof PREFECTURE_ANCHOR_CENTER | typeof PREFECTURE_ANCHOR_CAPITAL;
+
+/**
+ * 都道府県名からアンカー座標（中心 or 県庁所在地）を取得する。
+ * @param prefName 都道府県名（例: "東京都", "北海道"）
+ * @param anchor アンカー種別（"center" または "capital"、デフォルト: "center"）
+ * @returns 座標 [lng, lat]、取得できない場合は null
+ */
+export const getPrefectureAnchor = async (
+  prefName: string,
+  anchor: PrefectureAnchor = PREFECTURE_ANCHOR_CENTER,
+): Promise<[number, number] | null> => {
+  try {
+    // @geolonia/normalize-japanese-addresses を使用して都道府県情報を取得
+    const result = await normalize(prefName);
+
+    if (!result || !result.pref) {
+      console.warn(`都道府県 "${prefName}" が見つかりません`);
+      return null;
+    }
+
+    // アンカー種別に応じて座標を取得
+    if (anchor === PREFECTURE_ANCHOR_CAPITAL) {
+      // 県庁所在地の座標を取得
+      // 都道府県名 + "県庁所在地" で住所正規化を試みる
+      const capitalName = result.pref === '東京都' ? '東京' : result.pref.replace(/[都道府県]$/, '');
+      const capitalResult = await normalize(`${result.pref}${capitalName}`);
+
+      if (capitalResult && capitalResult.point && capitalResult.point.lat && capitalResult.point.lng) {
+        return [capitalResult.point.lng, capitalResult.point.lat];
+      }
+    }
+
+    // 中心座標（デフォルト）または県庁所在地が取得できなかった場合
+    if (result.point && result.point.lat && result.point.lng) {
+      return [result.point.lng, result.point.lat];
+    }
+
+    console.warn(`都道府県 "${prefName}" の座標を取得できません`);
+    return null;
+  } catch (error) {
+    console.error(`都道府県座標の取得に失敗: ${prefName}`, error);
+    return null;
+  }
+};
+
+/**
+ * 2地点座標から LineString GeoJSON FeatureCollection を生成する。
+ * @param from 始点座標 [lng, lat]
+ * @param to 終点座標 [lng, lat]
+ * @param properties 追加するプロパティ（オプション）
+ * @returns LineString GeoJSON FeatureCollection
+ */
+export const buildPrefectureLineFeature = (
+  from: [number, number],
+  to: [number, number],
+  properties: Record<string, any> = {},
+): GeoJSON.FeatureCollection<GeoJSON.LineString> => {
+  return {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: [from, to],
+        },
+        properties,
+      },
+    ],
+  };
+};
+
+/**
+ * 安定なレイヤー識別子を生成する。
+ * 再実行時に同じレイヤー名が生成されるため、上書き更新が可能。
+ * @param prefFrom 始点都道府県名
+ * @param pointFrom 始点アンカー種別
+ * @param prefTo 終点都道府県名
+ * @param pointTo 終点アンカー種別
+ * @returns レイヤー識別子（例: "line-東京-center-大阪-capital"）
+ */
+export const buildPrefectureLineLayerName = (
+  prefFrom: string,
+  pointFrom: PrefectureAnchor,
+  prefTo: string,
+  pointTo: PrefectureAnchor,
+): string => {
+  // 都道府県名を正規化（都道府県を除去）
+  const normalizePrefix = (name: string) => {
+    return name.replace(/[都道府県]/g, '').toLowerCase();
+  };
+
+  const from = normalizePrefix(prefFrom);
+  const to = normalizePrefix(prefTo);
+
+  return `line-${from}-${pointFrom}-${to}-${pointTo}`;
+};
+
+/**
+ * 2つの都道府県間の LineString を生成する（便利関数）。
+ * @param prefFrom 始点都道府県名
+ * @param anchorFrom 始点アンカー種別（デフォルト: "center"）
+ * @param prefTo 終点都道府県名
+ * @param anchorTo 終点アンカー種別（デフォルト: "center"）
+ * @returns LineString GeoJSON FeatureCollection、座標取得失敗時は null
+ */
+export const buildPrefectureLine = async (
+  prefFrom: string,
+  anchorFrom: PrefectureAnchor = PREFECTURE_ANCHOR_CENTER,
+  prefTo: string,
+  anchorTo: PrefectureAnchor = PREFECTURE_ANCHOR_CENTER,
+): Promise<{
+  geojson: GeoJSON.FeatureCollection<GeoJSON.LineString>;
+  layerName: string;
+} | null> => {
+  const from = await getPrefectureAnchor(prefFrom, anchorFrom);
+  const to = await getPrefectureAnchor(prefTo, anchorTo);
+
+  if (!from || !to) {
+    return null;
+  }
+
+  const geojson = buildPrefectureLineFeature(from, to, {
+    prefFrom,
+    anchorFrom,
+    prefTo,
+    anchorTo,
+  });
+
+  const layerName = buildPrefectureLineLayerName(prefFrom, anchorFrom, prefTo, anchorTo);
+
+  return { geojson, layerName };
+};

--- a/tests/prefectureUtils.test.ts
+++ b/tests/prefectureUtils.test.ts
@@ -1,0 +1,204 @@
+import {
+  getPrefectureAnchor,
+  buildPrefectureLineFeature,
+  buildPrefectureLineLayerName,
+  buildPrefectureLine,
+  PREFECTURE_ANCHOR_CENTER,
+  PREFECTURE_ANCHOR_CAPITAL,
+} from '../src/utils/prefectureUtils';
+
+// @geolonia/normalize-japanese-addresses のモック
+jest.mock('@geolonia/normalize-japanese-addresses', () => ({
+  normalize: jest.fn(),
+}));
+
+import { normalize } from '@geolonia/normalize-japanese-addresses';
+const mockNormalize = normalize as jest.MockedFunction<typeof normalize>;
+
+describe('getPrefectureAnchor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('中心座標（デフォルト）を返す', async () => {
+    mockNormalize.mockResolvedValueOnce({
+      pref: '東京都',
+      city: '',
+      town: '',
+      addr: '',
+      lat: 35.6762,
+      lng: 139.6503,
+      level: 1,
+      point: { lat: 35.6762, lng: 139.6503 },
+    } as any);
+
+    const result = await getPrefectureAnchor('東京都');
+    expect(result).not.toBeNull();
+    expect(result![0]).toBeCloseTo(139.6503, 3);
+    expect(result![1]).toBeCloseTo(35.6762, 3);
+  });
+
+  it('県庁所在地の座標を返す', async () => {
+    // 最初の呼び出し（都道府県名の正規化）
+    mockNormalize.mockResolvedValueOnce({
+      pref: '大阪府',
+      city: '',
+      town: '',
+      addr: '',
+      lat: 34.6937,
+      lng: 135.5023,
+      level: 1,
+      point: { lat: 34.6937, lng: 135.5023 },
+    } as any);
+    // 2回目の呼び出し（県庁所在地）
+    mockNormalize.mockResolvedValueOnce({
+      pref: '大阪府',
+      city: '大阪市',
+      town: '',
+      addr: '',
+      lat: 34.6937,
+      lng: 135.5023,
+      level: 2,
+      point: { lat: 34.6937, lng: 135.5023 },
+    } as any);
+
+    const result = await getPrefectureAnchor('大阪府', PREFECTURE_ANCHOR_CAPITAL);
+    expect(result).not.toBeNull();
+    expect(result![0]).toBeCloseTo(135.5023, 3);
+    expect(result![1]).toBeCloseTo(34.6937, 3);
+  });
+
+  it('存在しない都道府県名の場合は null を返す', async () => {
+    mockNormalize.mockResolvedValueOnce({
+      pref: '',
+      city: '',
+      town: '',
+      addr: '',
+      lat: null,
+      lng: null,
+      level: 0,
+    } as any);
+
+    const result = await getPrefectureAnchor('存在しない県');
+    expect(result).toBeNull();
+  });
+
+  it('normalize がエラーを投げた場合は null を返す', async () => {
+    mockNormalize.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await getPrefectureAnchor('東京都');
+    expect(result).toBeNull();
+  });
+
+  it('東京都の場合 capital アンカーで「東京」を使用する', async () => {
+    mockNormalize.mockResolvedValueOnce({
+      pref: '東京都',
+      city: '',
+      town: '',
+      addr: '',
+      lat: 35.6762,
+      lng: 139.6503,
+      level: 1,
+      point: { lat: 35.6762, lng: 139.6503 },
+    } as any);
+    mockNormalize.mockResolvedValueOnce({
+      pref: '東京都',
+      city: '東京',
+      town: '',
+      addr: '',
+      lat: 35.6895,
+      lng: 139.6917,
+      level: 2,
+      point: { lat: 35.6895, lng: 139.6917 },
+    } as any);
+
+    await getPrefectureAnchor('東京都', PREFECTURE_ANCHOR_CAPITAL);
+    expect(mockNormalize).toHaveBeenCalledTimes(2);
+    expect(mockNormalize).toHaveBeenCalledWith('東京都東京');
+  });
+});
+
+describe('buildPrefectureLineFeature', () => {
+  it('2地点から LineString FeatureCollection を生成する', () => {
+    const from: [number, number] = [139.6503, 35.6762];
+    const to: [number, number] = [135.5023, 34.6937];
+    const result = buildPrefectureLineFeature(from, to);
+
+    expect(result.type).toBe('FeatureCollection');
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0].geometry.type).toBe('LineString');
+    expect(result.features[0].geometry.coordinates).toEqual([from, to]);
+    expect(result.features[0].properties).toEqual({});
+  });
+
+  it('properties を指定できる', () => {
+    const from: [number, number] = [139.6503, 35.6762];
+    const to: [number, number] = [135.5023, 34.6937];
+    const result = buildPrefectureLineFeature(from, to, { color: 'red' });
+
+    expect(result.features[0].properties).toEqual({ color: 'red' });
+  });
+});
+
+describe('buildPrefectureLineLayerName', () => {
+  it('安定なレイヤー名を生成する', () => {
+    const name = buildPrefectureLineLayerName('東京都', PREFECTURE_ANCHOR_CENTER, '大阪府', PREFECTURE_ANCHOR_CAPITAL);
+    expect(name).toBe('line-東京-center-大阪-capital');
+  });
+
+  it('同じ引数で同じレイヤー名を返す（冪等性）', () => {
+    const name1 = buildPrefectureLineLayerName('北海道', PREFECTURE_ANCHOR_CENTER, '沖縄県', PREFECTURE_ANCHOR_CENTER);
+    const name2 = buildPrefectureLineLayerName('北海道', PREFECTURE_ANCHOR_CENTER, '沖縄県', PREFECTURE_ANCHOR_CENTER);
+    expect(name1).toBe(name2);
+  });
+
+  it('異なる引数で異なるレイヤー名を返す', () => {
+    const name1 = buildPrefectureLineLayerName('東京都', PREFECTURE_ANCHOR_CENTER, '大阪府', PREFECTURE_ANCHOR_CENTER);
+    const name2 = buildPrefectureLineLayerName('東京都', PREFECTURE_ANCHOR_CENTER, '大阪府', PREFECTURE_ANCHOR_CAPITAL);
+    expect(name1).not.toBe(name2);
+  });
+});
+
+describe('buildPrefectureLine', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('2つの都道府県間の LineString と layerName を返す', async () => {
+    mockNormalize
+      .mockResolvedValueOnce({
+        pref: '東京都',
+        point: { lat: 35.6762, lng: 139.6503 },
+      } as any)
+      .mockResolvedValueOnce({
+        pref: '大阪府',
+        point: { lat: 34.6937, lng: 135.5023 },
+      } as any);
+
+    const result = await buildPrefectureLine('東京都', PREFECTURE_ANCHOR_CENTER, '大阪府', PREFECTURE_ANCHOR_CENTER);
+    expect(result).not.toBeNull();
+    expect(result!.geojson.type).toBe('FeatureCollection');
+    expect(result!.geojson.features[0].geometry.type).toBe('LineString');
+    expect(result!.layerName).toBe('line-東京-center-大阪-center');
+  });
+
+  it('座標取得に失敗した場合は null を返す', async () => {
+    mockNormalize.mockResolvedValueOnce({
+      pref: '',
+    } as any);
+
+    const result = await buildPrefectureLine('不明', PREFECTURE_ANCHOR_CENTER, '大阪府', PREFECTURE_ANCHOR_CENTER);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/prefectureUtils.test.ts
+++ b/tests/prefectureUtils.test.ts
@@ -96,6 +96,29 @@ describe('getPrefectureAnchor', () => {
     expect(result).toBeNull();
   });
 
+  it('県庁所在地名が都道府県名から機械的に導けない場合も正しい市名で問い合わせる', async () => {
+    for (const [pref, expected] of [
+      ['北海道', '北海道札幌市'],
+      ['神奈川県', '神奈川県横浜市'],
+      ['愛知県', '愛知県名古屋市'],
+      ['兵庫県', '兵庫県神戸市'],
+      ['沖縄県', '沖縄県那覇市'],
+    ] as const) {
+      mockNormalize.mockReset();
+      mockNormalize.mockResolvedValueOnce({
+        pref, city: '', town: '', addr: '', lat: 35, lng: 139, level: 1,
+        point: { lat: 35, lng: 139 },
+      } as any);
+      mockNormalize.mockResolvedValueOnce({
+        pref, city: '', town: '', addr: '', lat: 35, lng: 139, level: 2,
+        point: { lat: 35, lng: 139 },
+      } as any);
+
+      await getPrefectureAnchor(pref, PREFECTURE_ANCHOR_CAPITAL);
+      expect(mockNormalize).toHaveBeenLastCalledWith(expected);
+    }
+  });
+
   it('東京都の場合 capital アンカーで「東京」を使用する', async () => {
     mockNormalize.mockResolvedValueOnce({
       pref: '東京都',
@@ -120,7 +143,7 @@ describe('getPrefectureAnchor', () => {
 
     await getPrefectureAnchor('東京都', PREFECTURE_ANCHOR_CAPITAL);
     expect(mockNormalize).toHaveBeenCalledTimes(2);
-    expect(mockNormalize).toHaveBeenCalledWith('東京都東京');
+    expect(mockNormalize).toHaveBeenCalledWith('東京都新宿区');
   });
 });
 
@@ -147,6 +170,15 @@ describe('buildPrefectureLineFeature', () => {
 });
 
 describe('buildPrefectureLineLayerName', () => {
+  it('都道府県名の末尾の接尾辞だけを取り除くこと', () => {
+    expect(
+      buildPrefectureLineLayerName('京都府', PREFECTURE_ANCHOR_CENTER, '大阪府', PREFECTURE_ANCHOR_CENTER),
+    ).toBe('line-京都-center-大阪-center');
+    expect(
+      buildPrefectureLineLayerName('東京都', PREFECTURE_ANCHOR_CENTER, '北海道', PREFECTURE_ANCHOR_CENTER),
+    ).toBe('line-東京-center-北海道-center');
+  });
+
   it('安定なレイヤー名を生成する', () => {
     const name = buildPrefectureLineLayerName('東京都', PREFECTURE_ANCHOR_CENTER, '大阪府', PREFECTURE_ANCHOR_CAPITAL);
     expect(name).toBe('line-東京-center-大阪-capital');


### PR DESCRIPTION
## Summary
- scratch の `prefecture-anchor.js` / `draw-prefecture-line.js` から都道府県関連の4関数+2定数を TypeScript で SDK に移植
- `getPrefectureAnchor(prefName, anchor)`: 都道府県名からアンカー座標（中心 or 県庁所在地）を取得
- `buildPrefectureLineFeature(from, to)`: 2地点座標から LineString GeoJSON FeatureCollection を生成
- `buildPrefectureLineLayerName(...)`: 再実行時に上書き可能な安定なレイヤー識別子を生成
- `buildPrefectureLine(...)`: 都道府県名を指定して LineString + layerName を一括生成
- `PREFECTURE_ANCHOR_CENTER` / `PREFECTURE_ANCHOR_CAPITAL` 定数
- `window.geolonia.japan.prefecture` からアクセス可能

## Functional Verification Criteria
- 都道府県名から中心座標・県庁所在地座標を正しく取得できる
- 東京都の場合は特別処理（「東京」を県庁所在地名として使用）
- 存在しない都道府県名や API エラー時に null を返し、例外を投げない
- 同じ引数で同じレイヤー名を返す（冪等性）

## Review Criteria
- `@geolonia/normalize-japanese-addresses` を活用し、`window` 依存を排除
- scratch の `resolveBlock` コールバック依存を排除し、純粋関数に変換
- エラーハンドリングが適切（try-catch + console.warn/error）
- 12テストケースでカバレッジ確保（normalize のモック使用）

closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 都道府県の中心座標または県庁所在地の座標を取得できるようになりました。
  * 都道府県間を結ぶ地図上のラインを生成できるようになりました。
  * 都道府県名やラインに関する機能を、新しい公開 API から利用できるようになりました。
  * 県庁所在地が特定できない場合は、都道府県の中心座標を使用します。

* **テスト**
  * 都道府県関連機能の動作を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->