### PR TITLE
feat: Nominatim ベースの住所・施設検索 API クライアント searchPlaces() を追加 (#110)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { setLineStyle, LineStyleOptions } from './utils/lineStyleUtils';
 import { baseMapStyleUrl } from './utils/baseMapStyleUtils';
 import { fetchTottoriDataIndex, addTottoriDataSource, addTottoriDataLayer, removeTottoriDataLayer, TottoriDataEntry } from './utils/tottoriDataUtils';
 import { nearestPointOnSegment, nearestPointOnLine, bearingBetweenPoints, distanceBetweenPoints, collectLineFeatures } from './utils/geometryUtils';
+import { searchPlaces } from './utils/searchPlaces';
 
 declare global {
   interface Window {
@@ -795,3 +796,5 @@ window.geolonia.japan.geometry = {
   distanceBetweenPoints,
   collectLineFeatures,
 };
+
+window.geolonia.japan.searchPlaces = searchPlaces;

--- a/src/utils/searchPlaces.ts
+++ b/src/utils/searchPlaces.ts
@@ -1,0 +1,61 @@
+const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
+const DEFAULT_LIMIT = 10;
+const USER_AGENT = "japan-cityos-sdk/1.0 (https://github.com/geolonia/japan-cityos-sdk)";
+
+export type SearchResult = {
+  id: string;
+  name: string;
+  address: string;
+  lng: number;
+  lat: number;
+  source: "nominatim";
+};
+
+type NominatimItem = {
+  place_id: string;
+  display_name: string;
+  name?: string;
+  lon: string;
+  lat: string;
+};
+
+function toSearchResult(item: NominatimItem): SearchResult {
+  const parts = item.display_name.split(", ");
+  const name = item.name || parts[0];
+  const address = parts.slice(1).join(", ");
+  return {
+    id: String(item.place_id),
+    name,
+    address,
+    lng: parseFloat(item.lon),
+    lat: parseFloat(item.lat),
+    source: "nominatim",
+  };
+}
+
+export async function searchPlaces(
+  query: string,
+  options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<SearchResult[]> {
+  const { limit = DEFAULT_LIMIT, signal } = options;
+
+  const params = new URLSearchParams({
+    q: query,
+    format: "json",
+    limit: String(limit),
+    addressdetails: "1",
+  });
+
+  const res = await fetch(`${NOMINATIM_URL}?${params}`, {
+    headers: { "User-Agent": USER_AGENT },
+    signal,
+  });
+
+  if (!res.ok) {
+    const text = (await res.text()) || res.statusText;
+    throw new Error(`${res.status}: ${text}`);
+  }
+
+  const items: NominatimItem[] = await res.json();
+  return items.map(toSearchResult);
+}

--- a/tests/searchPlaces.test.ts
+++ b/tests/searchPlaces.test.ts
@@ -1,0 +1,170 @@
+import { searchPlaces, type SearchResult } from '../src/utils/searchPlaces';
+
+const mockFetch = jest.fn();
+
+beforeAll(() => {
+  global.fetch = mockFetch;
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const makeNominatimResponse = (overrides: object[] = [{}]) =>
+  overrides.map((o, i) => ({
+    place_id: `place-${i}`,
+    display_name: `施設名 ${i}, 東京都千代田区, 日本`,
+    name: `施設名 ${i}`,
+    address: {
+      city: '千代田区',
+      state: '東京都',
+      country: '日本',
+    },
+    lon: `139.${700 + i}`,
+    lat: `35.${680 + i}`,
+    ...o,
+  }));
+
+describe('searchPlaces', () => {
+  describe('正常系', () => {
+    it('クエリに対して SearchResult 配列を返す', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(makeNominatimResponse([{}, {}])),
+      });
+
+      const results = await searchPlaces('東京タワー');
+
+      expect(results).toHaveLength(2);
+      const first = results[0];
+      expect(first).toMatchObject<Partial<SearchResult>>({
+        id: expect.any(String),
+        name: expect.any(String),
+        address: expect.any(String),
+        lng: expect.any(Number),
+        lat: expect.any(Number),
+        source: 'nominatim',
+      });
+    });
+
+    it('lng と lat が数値として返る', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve(makeNominatimResponse([{ lon: '139.7670', lat: '35.6804' }])),
+      });
+
+      const results = await searchPlaces('新宿');
+
+      expect(results[0].lng).toBe(139.767);
+      expect(results[0].lat).toBe(35.6804);
+    });
+
+    it('limit オプションがクエリパラメータに反映される', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+      await searchPlaces('渋谷', { limit: 3 });
+
+      const url = new URL(mockFetch.mock.calls[0][0] as string);
+      expect(url.searchParams.get('limit')).toBe('3');
+    });
+
+    it('デフォルト limit が適用される', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+      await searchPlaces('渋谷');
+
+      const url = new URL(mockFetch.mock.calls[0][0] as string);
+      expect(Number(url.searchParams.get('limit'))).toBeGreaterThan(0);
+    });
+
+    it('空結果の場合は空配列を返す（クライアントが落ちない）', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+      const results = await searchPlaces('存在しない場所');
+
+      expect(results).toEqual([]);
+    });
+
+    it('User-Agent ヘッダーを付与する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+      await searchPlaces('test');
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)['User-Agent']).toBeDefined();
+    });
+  });
+
+  describe('異常系', () => {
+    it('ネットワークエラーで例外をスロー', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      await expect(searchPlaces('東京')).rejects.toThrow();
+    });
+
+    it('429 レート制限でエラーをスロー', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        text: () => Promise.resolve('Too Many Requests'),
+      });
+
+      await expect(searchPlaces('東京')).rejects.toThrow(/429/);
+    });
+
+    it('500 サーバーエラーでエラーをスロー', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve('Internal Server Error'),
+      });
+
+      await expect(searchPlaces('東京')).rejects.toThrow(/500/);
+    });
+  });
+
+  describe('キャンセル', () => {
+    it('AbortSignal を渡すと fetch にそのまま転送する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+      const controller = new AbortController();
+      await searchPlaces('東京', { signal: controller.signal });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.signal).toBe(controller.signal);
+    });
+
+    it('中断済み AbortSignal でフェッチを開始すると AbortError が発生する', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      mockFetch.mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+
+      await expect(
+        searchPlaces('東京', { signal: controller.signal }),
+      ).rejects.toMatchObject({ name: 'AbortError' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Nominatim (OpenStreetMap) を使用した住所・施設検索 API クライアント `searchPlaces()` を SDK に追加
- `SearchResult` 型を export（id, name, address, lng, lat, source）
- AbortSignal によるリクエストキャンセル対応
- User-Agent を `japan-cityos-sdk/1.0` に設定
- `window.geolonia.japan.searchPlaces` からアクセス可能

## Functional Verification Criteria
- クエリ文字列で住所・施設を検索し、SearchResult 配列を返す
- limit オプションで取得件数を制御できる
- 空結果の場合は空配列を返す（例外を投げない）
- HTTP エラー（429, 500 等）で適切な Error をスロー
- AbortSignal でリクエストをキャンセルできる

## Review Criteria
- Nominatim API の利用規約に準拠（User-Agent 設定）
- 型安全な API 設計（SearchResult 型）
- エラーハンドリングが適切
- 11テストケースで正常系・異常系・キャンセルをカバー

closes #110