### PR TITLE
fix: スタイル切り替え時の DEM dimension mismatch エラーを修正 (#111)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,40 +301,50 @@ class GeoloniaMap extends MapsCoreGeoloniaMap {
    * @param styleUrlOrObject スタイルのURLまたはオブジェクト
    ****************/
   setBaseMapStyle(styleUrlOrObject: string | maplibregl.StyleSpecification) {
-    // 3D地形の状態を保持
+    // 3D地形の状態を保持（スタイル切替後に復元するため）
     const terrainState = this.getTerrain();
     const hadTerrain = !!terrainState;
+    const exaggeration = terrainState?.exaggeration ?? 1;
+
+    // DEM dimension mismatch 防止: スタイル切替前にテレインを無効化
+    // 古い DEM タイルキャッシュが新しいスタイルの DEM タイルと
+    // 次元不一致を起こすのを防ぐ (#111)
+    if (hadTerrain) {
+      this.setTerrain(null);
+    }
 
     this.setStyle(styleUrlOrObject, {
       transformStyle: (previousStyle, nextStyle) => {
         const newSources = mergeSourcesByLoadedIds(previousStyle.sources, nextStyle.sources, this.loadedSourceIds);
         const newLayers = mergeLayersByLoadedIds(previousStyle.layers, nextStyle.layers, this.loadedSourceIds);
 
-        // terrain用のソースとレイヤーを保持
-        const terrainSourceId = terrainState?.source ?? this.TERRAIN_SOURCE_ID;
-        if (terrainSourceId && hadTerrain) {
-          if (previousStyle.sources[terrainSourceId]) {
-            newSources[terrainSourceId] = previousStyle.sources[terrainSourceId];
-          }
-          const hillshadeLayerId = GeoloniaMap.HILLSHADE_LAYER_ID;
-          if (!newLayers.some(l => l.id === hillshadeLayerId)) {
-            const hillshadeLayer = previousStyle.layers.find(l => l.id === hillshadeLayerId);
-            if (hillshadeLayer) {
-              newLayers.push(hillshadeLayer);
-            }
-          }
-        }
+        // DEM ソースは保持しない（新しいスタイルのロード後に再追加する）
+        // 古い DEM タイルを引き継ぐと backfillBorder で
+        // dim mismatch エラーが発生するため (#111)
 
-        const canRestoreTerrain = hadTerrain && !!terrainSourceId && !!newSources[terrainSourceId];
         return {
           ...previousStyle,
           ...nextStyle,
           sources: newSources,
           layers: newLayers,
-          ...(canRestoreTerrain ? { terrain: { source: terrainSourceId, exaggeration: terrainState.exaggeration ?? 1 } } : {})
         };
       }
     });
+
+    // スタイルロード後にテレインを新しい DEM ソースで復元
+    if (hadTerrain) {
+      this.once('styledata', () => {
+        addTerrainSource(this, this.apiKey);
+        if (this.getLayer(HILLSHADE_LAYER_ID)) {
+          this.removeLayer(HILLSHADE_LAYER_ID);
+        }
+        addHillshadeLayer(this);
+        this.setTerrain({
+          source: this.TERRAIN_SOURCE_ID,
+          exaggeration,
+        });
+      });
+    }
   }
 
   /****************


### PR DESCRIPTION
## Summary
- `setBaseMapStyle()` でスタイル切り替え時に古い DEM ソースを保持していたことが原因で、MapLibre GL の `backfillBorder()` で `dem dimension mismatch` エラーが連続発生していた問題を修正
- スタイル切替前にテレインを無効化し、切替後に新しい DEM ソースで再構築する方式に変更
- exaggeration 値は切替前の状態を保持

## Root Cause
`transformStyle` 内で `previousStyle.sources[terrainSourceId]` をそのまま新スタイルに引き継いでいたため、古い DEM タイルキャッシュと新しい DEM タイルの間で `dim`（タイル次元）が不一致になっていた。MapLibre GL の `DEMData.backfillBorder()` は隣接タイル間で `this.dim !== borderTile.dim` の場合 `throw new Error('dem dimension mismatch')` するため、エラーが連続発生していた。

## Functional Verification Criteria
- スタイル切り替え後に DEM dimension mismatch エラーが発生しない
- スタイル切り替え前に3D地形が有効だった場合、切り替え後も自動復元される
- exaggeration 値が切り替え前と同じ値で復元される
- ユーザーが追加したカスタムレイヤーは従来通り保持される

## Review Criteria
- DEM ソースの引き継ぎを停止し、新しい DEM ソースで再構築する設計
- `styledata` イベントで非同期にテレインを再構築するタイミングが適切
- テレイン無効化→スタイル切替→テレイン復元の順序が正しい
- 既存テスト 230 件が全パス

closes #111