### PR TITLE
fix: GitHub Pagesデモページの地図403エラーを修正 & プロジェクトドキュメント追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,130 @@
 # Japan Maps SDK
 
+日本向け地図表示 SDK。MapLibre GL JS ベースの `@geolonia/maps-core` を拡張し、GeoJSON / CSV データの表示、OSM POI、ハザードマップ、国土数値情報、3D 地形などの機能を提供する。
+
+**デモ:** [https://geolonia.github.io/japan-cityos-sdk/](https://geolonia.github.io/japan-cityos-sdk/)
+
+**CDN:**
+```
 https://geolonia.github.io/japan-cityos-sdk/index.js
-
-地図を表示する
-```
-const japanMap = new geolonia.japan.Map({
-    container: 'map',
-    lngLat: [],
-    zoom: 12,
-})
 ```
 
-CSVデータを読み込む
-> japanMap.loadCSV(url, sourceName, simpleStyleObject)
+## クイックスタート
+
+```html
+<div id="map" style="width: 100%; height: 400px;"></div>
+<script src="https://geolonia.github.io/japan-cityos-sdk/index.js?api-key=YOUR-API-KEY"></script>
+<script>
+const map = new geolonia.japan.Map({
+  lngLat: [139.6917, 35.6895],
+  zoom: 12,
+});
+</script>
 ```
-const url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSv5OOG_biAGX5Q2XXrBPEtfthDNmFFtwPd50wCRON4aphbQMPHUWXtvzZ7UUjOFGhmNSv3h_jE-tyu/pub?gid=2058114753&single=true&output=csv'
-japanMap.loadCSV(url, '選挙時投票所一覧', {
-    'marker-color': '#eba037'
+
+### CSV データの読み込み
+
+```javascript
+map.loadCSV(url, 'layer-name', { 'marker-color': '#eba037' });
+```
+
+### GeoJSON データの読み込み
+
+```javascript
+map.loadGeojson(geojson, 'layer-name', {
+  'marker-symbol': 'chizubouken-lab:cafe',
 });
 ```
 
-GeoJsonデータを読み込む
-> japanMap.loadGeojson(geojson, sourceName, simpleStyleObject)
+## ディレクトリ構成
+
 ```
-japanMap.loadGeojson(geojson, 'restaurant', {
-    'marker-symbol': 'marker:restaurant',
-    'marker-size': 'large',
-});
+japan-cityos-sdk/
+│
+├── src/                        ソースコード
+│   ├── index.ts               エントリポイント（GeoloniaMap クラス定義）
+│   ├── constants.ts           デフォルト色・サイズなどの定数
+│   ├── types.ts               型定義（OsmLayerNameType）
+│   ├── setFillStyle.ts        ポリゴンスタイル設定
+│   ├── toQueryBox.ts          座標→ピクセルクエリ変換
+│   └── utils/                 ユーティリティモジュール群
+│       ├── mapUtils.ts            コア操作（CSV変換, レイヤー管理, APIキー解析）
+│       ├── geojsonUtils.ts        GeoJSON パース・ジオメトリ型検出
+│       ├── geometryUtils.ts       地理座標計算（距離, 方位角, 最近点）
+│       ├── sourceUtils.ts         GeoJSON ソース追加・更新
+│       ├── layerUtils.ts          レイヤー追加・更新
+│       ├── layerConfig.ts         レイヤー構成テンプレート
+│       ├── createLayer.ts         レイヤーファクトリ関数
+│       ├── circleStyleUtils.ts    サークルスタイル操作
+│       ├── lineStyleUtils.ts      ラインスタイル操作
+│       ├── baseMapStyleUtils.ts   背景地図スタイル URL 定義
+│       ├── spriteUtils.ts         スプライトシート（アイコン）管理
+│       ├── osmPoiUtils.ts         OSM POI レイヤー管理
+│       ├── osmStyles.ts           OSM レイヤーのスタイル定義
+│       ├── hazardmapUtils.ts      ハザードマップ（12種類）
+│       ├── nationalLandNumericalInformationUtils.ts
+│       │                          国土数値情報データ（8種類）
+│       ├── tottoriDataUtils.ts    鳥取県スマートシティデータ
+│       ├── terrainUtils.ts        3D 地形・DEM 表示
+│       ├── japaneseAdminsUtils.ts 行政区域境界 GeoJSON 取得
+│       ├── resolveLatLng.ts       住所→座標変換
+│       └── fetchJson.ts           HTTP JSON フェッチ
+│
+├── tests/                      テストスイート（41ファイル, 230テスト）
+│   ├── __mocks__/             モックユーティリティ
+│   └── *.test.ts              各ユーティリティのテスト
+│
+├── public/
+│   └── index.html             デモページ（HTML テンプレート）
+│
+├── docs/                       ビルド出力（GitHub Pages 公開ディレクトリ）
+│   ├── index.js               UMD バンドル
+│   ├── index.js.map           ソースマップ
+│   └── index.html             デモページ（public/ からコピー）
+│
+├── documentation/              プロジェクトドキュメント
+│   ├── getting-started.md     導入ガイド・基本的な使い方
+│   ├── api-reference.md       GeoloniaMap クラスの全 API リファレンス
+│   ├── data-sources.md        利用可能なデータソース一覧と使い方
+│   ├── architecture.md        アーキテクチャ・ビルド・ディレクトリ構造
+│   └── utilities.md           ユーティリティ関数の詳細リファレンス
+│
+├── rollup.config.mjs          Rollup ビルド設定
+├── tsconfig.json              TypeScript 設定
+├── jest.config.js             Jest テスト設定
+└── package.json               パッケージ情報・npm スクリプト
 ```
+
+## npm スクリプト
+
+| コマンド | 説明 |
+|---------|------|
+| `npm run build` | `docs/` にバンドルをビルド |
+| `npm test` | Jest テストを実行 |
+| `npm start` | `docs/` をローカルサーバーで配信 |
+
+## 主な機能
+
+| 機能 | 説明 | 詳細 |
+|------|------|------|
+| 地図表示 | MapLibre GL ベースの地図描画 | [getting-started.md](documentation/getting-started.md) |
+| CSV / GeoJSON | データ読み込みとスタイル指定 | [api-reference.md](documentation/api-reference.md) |
+| OSM POI | 16 種類の OpenStreetMap 地物表示 | [data-sources.md](documentation/data-sources.md) |
+| ハザードマップ | 洪水・津波等 12 種類の防災データ | [data-sources.md](documentation/data-sources.md) |
+| 国土数値情報 | 学区・医療機関等 8 種類の公共データ | [data-sources.md](documentation/data-sources.md) |
+| 3D 地形 | DEM + 陰影起伏による立体表示 | [api-reference.md](documentation/api-reference.md) |
+| スタイル変更 | サークル・ライン・ポリゴンの動的スタイリング | [api-reference.md](documentation/api-reference.md) |
+| 座標計算 | 距離・方位角・最近点のジオメトリ計算 | [utilities.md](documentation/utilities.md) |
+| 住所検索 | 都道府県・市区町村名から中心座標を取得 | [api-reference.md](documentation/api-reference.md) |
+
+## ドキュメント
+
+- **[導入ガイド](documentation/getting-started.md)** — CDN 利用方法、地図の作成、データ読み込みの基本
+- **[API リファレンス](documentation/api-reference.md)** — GeoloniaMap クラスの全メソッド・プロパティ
+- **[データソース](documentation/data-sources.md)** — OSM POI、ハザードマップ、国土数値情報等の一覧と使い方
+- **[アーキテクチャ](documentation/architecture.md)** — 技術スタック、ビルドプロセス、クラス設計
+- **[ユーティリティ](documentation/utilities.md)** — 座標計算、GeoJSON パース等の関数リファレンス
+
+## ライセンス
+
+MIT

--- a/docs/index.html
+++ b/docs/index.html
@@ -505,7 +505,7 @@
 
   <div id="center-crosshair"></div>
   <div id="map"></div>
-  <script src="./index.js"></script>
+  <script src="./index.js?api-key=e3b7017e263c4bb39267b11a469ba286"></script>
   <script type="application/javascript">
     // セクション折りたたみ
     function toggleSection(sectionId) {

--- a/documentation/api-reference.md
+++ b/documentation/api-reference.md
@@ -1,0 +1,409 @@
+# API Reference
+
+## GeoloniaMap クラス
+
+`@geolonia/maps-core` の `GeoloniaMap` を拡張したメインクラス。`geolonia.japan.Map` としてグローバルに公開される。
+
+---
+
+## データ読み込み
+
+### `loadCSV(url, className, simpleStyle?)`
+
+CSV ファイルを読み込み、GeoJSON に変換して地図上に表示する。
+
+- **url** `string` — CSV ファイルの URL
+- **className** `string` — レイヤー名（ソース ID としても使用）
+- **simpleStyle** `object` — SimpleStyle 形式のスタイル指定（任意）
+
+CSV の緯度・経度カラムは以下の名前を自動検出する: `lat`/`lng`, `latitude`/`longitude`, `緯度`/`経度` など。
+
+### `loadGeojson(geojson, className, simpleStyle?)`
+
+GeoJSON データを地図上に表示する。
+
+- **geojson** `GeoJSON.FeatureCollection | string` — GeoJSON オブジェクトまたは URL 文字列
+- **className** `string` — レイヤー名
+- **simpleStyle** `object` — SimpleStyle 形式のスタイル指定（任意）
+
+### `loadData(className, simpleStyle?)`
+
+事前定義されたデータクラスを読み込む。
+
+- **className** `string` — データクラス名
+- **simpleStyle** `object` — スタイル指定（任意）
+
+### `removeGeojsonLayer(className)`
+
+GeoJSON レイヤーとソースを削除する。
+
+- **className** `string` — 削除するレイヤー名
+
+---
+
+## OSM POI（OpenStreetMap 地物）
+
+### `loadOsmPoi(osmLayerName, spriteName?)`
+
+OSM の POI レイヤーを表示する。
+
+- **osmLayerName** `OsmLayerNameType` — POI 種別名
+- **spriteName** `string` — 使用するスプライトシート名（任意）
+
+### `removeOsmPoi(osmLayerName)`
+
+OSM POI レイヤーを非表示にする。
+
+### 利用可能な OSM POI 種別
+
+| 種別名 | 説明 |
+|--------|------|
+| `restaurant` | レストラン |
+| `cafe` | カフェ |
+| `fast-food` | ファストフード |
+| `convenience` | コンビニ |
+| `bank` | 銀行 |
+| `hospital` | 病院 |
+| `school` | 学校 |
+| `college` | 大学 |
+| `railway` | 鉄道駅 |
+| `airport` | 空港 |
+| `mountain` | 山 |
+| `zoo` | 動物園 |
+| `parking` | 駐車場 |
+| `castle` | 城 |
+| `museum` | 博物館 |
+| `park` | 公園 |
+
+---
+
+## ハザードマップ
+
+### `loadHazardMapData(layerId)`
+
+防災関連のラスタータイルレイヤーを表示する。
+
+- **layerId** `string` — ハザードマップ ID
+
+### `removeHazardMapData(layerId)`
+
+ハザードマップレイヤーを非表示にする。
+
+利用可能なハザードマップの一覧は `GeoloniaMap.getHazardMapData()` で取得可能。洪水浸水想定、高潮浸水想定、津波浸水想定、土砂災害警戒区域、雪崩危険区域など 12 種類。
+
+---
+
+## 国土数値情報（NLNI）
+
+### `loadNLNIData(layerId)`
+
+国土数値情報のベクタータイルレイヤーを表示する。
+
+- **layerId** `string` — NLNI データ ID
+
+### `removeNLNIData(layerId)`
+
+NLNI レイヤーを非表示にする。
+
+利用可能なデータの一覧は `GeoloniaMap.getNLNIData()` で取得可能。小学校区、中学校区、学校、医療機関、人口推計、駅乗降客数、市区町村役場、盛土地図など 8 種類。
+
+---
+
+## 鳥取県スマートシティデータ
+
+### `loadTottoriData(dataId)`
+
+鳥取県スマートシティデータのタイルレイヤーを表示する。
+
+- **dataId** `string` — データ ID
+
+### `removeTottoriData(dataId)`
+
+鳥取県データレイヤーを非表示にする。
+
+利用可能なデータの一覧は `GeoloniaMap.getTottoriData()` で取得可能。
+
+---
+
+## 背景地図スタイル
+
+### `setBaseMapStyle(styleUrl)`
+
+背景地図のスタイルを切り替える。
+
+- **styleUrl** `string` — スタイル JSON の URL
+
+### 利用可能な背景地図
+
+| キー | 説明 |
+|------|------|
+| `basic` | Geolonia Basic スタイル |
+| `hakuchizu` | 白地図スタイル |
+| `hakuchizu-nolabel` | 白地図（ラベルなし） |
+| `hakuchizu-notext` | 白地図（テキストなし） |
+
+スタイル URL は `GeoloniaMap.baseMapStyleUrl` プロパティから取得可能。全スタイル一覧は `GeoloniaMap.getBaseMapStyles()` で取得可能。
+
+---
+
+## 3D 地形
+
+### `show3DTerrain()`
+
+3D 地形表示（DEM + 陰影起伏）を有効にする。
+
+### `hide3DTerrain()`
+
+3D 地形を無効にし、2D 表示に戻す。
+
+### `getElevation(lngLat)`
+
+指定座標の標高を取得する。
+
+- **lngLat** `[number, number]` — `[経度, 緯度]`
+- **戻り値** `Promise<number>` — 標高（メートル）
+
+---
+
+## レイヤースタイル変更
+
+### `setSymbolIconSize(className, size)`
+
+シンボルレイヤーのアイコンサイズを変更する。
+
+- **className** `string` — レイヤー名
+- **size** `number` — アイコンサイズ（デフォルト: 1.0）
+
+### `setCircleStyle(className, style)`
+
+サークルレイヤーのスタイルを変更する。
+
+- **className** `string` — レイヤー名
+- **style** `CircleStyleOptions`
+
+```typescript
+interface CircleStyleOptions {
+  color?: string;       // 塗りつぶし色
+  radius?: number;      // 半径（ピクセル）
+  strokeColor?: string; // 枠線色
+  strokeWidth?: number; // 枠線幅
+  opacity?: number;     // 不透明度（0-1）
+}
+```
+
+### `setFillStyle(className, style)`
+
+ポリゴンレイヤーのスタイルを変更する。
+
+- **className** `string` — レイヤー名
+- **style** `FillStyleOptions`
+
+```typescript
+interface FillStyleOptions {
+  color?: string;        // 塗りつぶし色
+  opacity?: number;      // 不透明度（0-1）
+  outlineColor?: string; // 輪郭線色
+}
+```
+
+### `setLineStyle(className, style)`
+
+ラインレイヤーのスタイルを変更する。
+
+- **className** `string` — レイヤー名
+- **style** `LineStyleOptions`
+
+```typescript
+interface LineStyleOptions {
+  color?: string;   // 線色
+  width?: number;   // 線幅
+  opacity?: number; // 不透明度（0-1）
+}
+```
+
+---
+
+## フィーチャクエリ
+
+### `hasFeature(xy, layerIds?)`
+
+指定座標にフィーチャが存在するか確認する。
+
+- **xy** `[number, number] | [[number, number], [number, number]]` — ピクセル座標またはバウンディングボックス
+- **layerIds** `string[]` — 検索対象レイヤー ID（任意）
+- **戻り値** `boolean`
+
+### `getFeatures(xy, options?)`
+
+指定座標のフィーチャオブジェクトを取得する。
+
+- **xy** — 座標指定
+- **options** — クエリオプション
+- **戻り値** `Feature[]`
+
+### `getFeaturesProperties(xy, options?)`
+
+指定座標のフィーチャプロパティのみを取得する。
+
+---
+
+## マーカー
+
+### `addImageMarker(imageUrl, lat, lon, name?)`
+
+カスタム画像マーカーを追加する。
+
+- **imageUrl** `string` — 画像 URL
+- **lat** `number` — 緯度
+- **lon** `number` — 経度
+- **name** `string` — マーカー名（任意）
+
+### `removeImageMarker(lat, lon, name?)`
+
+画像マーカーを削除する。
+
+### `removeAllImageMarkers()`
+
+全画像マーカーを削除する。
+
+### `setImageMarkerWidth(name, width)`
+
+画像マーカーの表示幅を変更する。
+
+---
+
+## レイヤーアイコン変更
+
+### `changeLayerIcon(layerId, iconName, spriteKey?)`
+
+特定レイヤーのアイコンを変更する。
+
+- **layerId** `string` — レイヤー ID
+- **iconName** `string` — 新しいアイコン名
+- **spriteKey** `string` — スプライトシートキー（任意）
+
+---
+
+## カスタムレイヤー管理
+
+### `removeAllCustomLayers()`
+
+ユーザーが追加した全カスタムレイヤーを削除する。
+
+---
+
+## 静的メソッド
+
+### `GeoloniaMap.getOsmPoiLayers()`
+
+利用可能な OSM POI 種別の一覧を取得する。
+
+### `GeoloniaMap.getHazardMapData()`
+
+利用可能なハザードマップの一覧を取得する。
+
+### `GeoloniaMap.getNLNIData()`
+
+利用可能な国土数値情報データの一覧を取得する。
+
+### `GeoloniaMap.getBaseMapStyles()`
+
+利用可能な背景地図スタイルの一覧を取得する。
+
+### `GeoloniaMap.getTottoriData()`
+
+鳥取県スマートシティデータの一覧を取得する。
+
+- **戻り値** `Promise<TottoriDataEntry[]>`
+
+### `GeoloniaMap.getIconNames(spriteKey)`
+
+スプライトシートに含まれるアイコン名の一覧を取得する。
+
+- **spriteKey** `string` — スプライトキー
+- **戻り値** `Promise<string[]>`
+
+### `GeoloniaMap.getIconStyles(spriteKey)`
+
+スプライトシートの各アイコンの CSS スタイル情報を取得する。
+
+- **spriteKey** `string` — スプライトキー
+- **戻り値** `Promise<{width, height, backgroundImage, backgroundPosition}[]>`
+
+### `GeoloniaMap.fetchPrefNames()`
+
+全都道府県名の一覧を取得する。
+
+- **戻り値** `Promise<string[]>`
+
+### `GeoloniaMap.fetchCityNames(prefName)`
+
+指定都道府県の市区町村名一覧を取得する。
+
+- **prefName** `string` — 都道府県名
+- **戻り値** `Promise<string[]>`
+
+### `GeoloniaMap.getLatLngByPrefecture(prefName)`
+
+都道府県の中心座標を取得する。
+
+- **prefName** `string` — 都道府県名
+- **戻り値** `Promise<[number, number] | null>`
+
+### `GeoloniaMap.getLatLngByCity(prefName, cityName)`
+
+市区町村の中心座標を取得する。
+
+- **prefName** `string` — 都道府県名
+- **cityName** `string` — 市区町村名
+- **戻り値** `Promise<[number, number] | null>`
+
+---
+
+## 静的プロパティ
+
+### `GeoloniaMap.spriteSheetUrl`
+
+利用可能なスプライトシートの URL マップ。
+
+```javascript
+{
+  'chizubouken-lab': 'https://geolonia.github.io/chizubouken-lab-sprite/sprite',
+  'mapfan':          'https://geolonia.github.io/mapfandb-sprite/sprite',
+  'smartmap':        'https://geolonia.github.io/custom-smartmap-sprite/sprite',
+  'basic':           'https://geoloniamaps.github.io/basic-v1/basic-v1',
+}
+```
+
+### `GeoloniaMap.baseMapStyleUrl`
+
+利用可能な背景地図スタイル URL のマップ。
+
+---
+
+## デフォルト定数
+
+| 定数 | 値 | 説明 |
+|------|----|------|
+| `DEFAULT_CIRCLE_COLOR` | `#FF0000` | サークルのデフォルト色 |
+| `DEFAULT_LINE_COLOR` | `#0000FF` | ラインのデフォルト色 |
+| `DEFAULT_FILL_COLOR` | `#00FF00` | ポリゴンのデフォルト色 |
+| `DEFAULT_FILL_OPACITY` | `0.5` | ポリゴンのデフォルト不透明度 |
+| `DEFAULT_LINE_WIDTH` | `2` | ラインのデフォルト幅 |
+| `BOLD_LINE_WIDTH` | `4` | 太線幅 |
+
+### マーカーサイズ
+
+| サイズ名 | 値 |
+|----------|----|
+| `small` | 0.3 |
+| `medium` | 0.5 |
+| `large` | 1.0 |
+
+### サークルサイズ
+
+| サイズ名 | 半径 (px) |
+|----------|-----------|
+| `small` | 3 |
+| `medium` | 6 |
+| `large` | 10 |

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -1,0 +1,135 @@
+# アーキテクチャ
+
+## 技術スタック
+
+| 項目 | 技術 |
+|------|------|
+| 言語 | TypeScript 5.0 |
+| 地図エンジン | MapLibre GL JS（`@geolonia/maps-core` 経由） |
+| ビルド | Rollup（UMD バンドル） |
+| テスト | Jest + ts-jest（jsdom 環境） |
+| CSS | SCSS（JS にインライン挿入） |
+
+## ディレクトリ構造
+
+```
+japan-cityos-sdk/
+├── src/                     # ソースコード
+│   ├── index.ts            # エントリポイント（GeoloniaMap クラス）
+│   ├── constants.ts        # デフォルト色・サイズ等の定数
+│   ├── types.ts            # 型定義（OsmLayerNameType）
+│   ├── setFillStyle.ts     # ポリゴンスタイル設定
+│   ├── toQueryBox.ts       # 座標→ピクセル変換
+│   └── utils/              # ユーティリティモジュール群
+│       ├── mapUtils.ts             # コア地図操作（CSV変換, レイヤー管理, APIキー解析）
+│       ├── geojsonUtils.ts         # GeoJSON パース・ジオメトリ型検出
+│       ├── geometryUtils.ts        # 地理座標計算（距離, 方位角, 最近点）
+│       ├── sourceUtils.ts          # GeoJSON ソース管理
+│       ├── layerUtils.ts           # レイヤー追加・更新
+│       ├── layerConfig.ts          # レイヤー構成テンプレート
+│       ├── createLayer.ts          # レイヤーファクトリ関数
+│       ├── circleStyleUtils.ts     # サークルスタイル
+│       ├── lineStyleUtils.ts       # ラインスタイル
+│       ├── baseMapStyleUtils.ts    # 背景地図スタイル URL
+│       ├── spriteUtils.ts          # スプライトシート管理
+│       ├── osmPoiUtils.ts          # OSM POI レイヤー管理
+│       ├── osmStyles.ts            # OSM レイヤースタイル定義
+│       ├── hazardmapUtils.ts       # ハザードマップデータ
+│       ├── nationalLandNumericalInformationUtils.ts  # 国土数値情報データ
+│       ├── tottoriDataUtils.ts     # 鳥取県スマートシティデータ
+│       ├── terrainUtils.ts         # 3D 地形・DEM
+│       ├── japaneseAdminsUtils.ts  # 行政区域境界 GeoJSON
+│       ├── resolveLatLng.ts        # 住所→座標変換
+│       └── fetchJson.ts            # HTTP JSON フェッチ
+├── tests/                   # テストスイート（41ファイル, 230テスト）
+│   ├── __mocks__/          # モックユーティリティ
+│   └── *.test.ts           # 各ユーティリティのテスト
+├── public/
+│   └── index.html          # デモページ（HTML テンプレート）
+├── docs/                    # ビルド出力（GitHub Pages 公開）
+│   ├── index.js            # UMD バンドル
+│   ├── index.js.map        # ソースマップ
+│   └── index.html          # デモページ（public/ からコピー）
+├── documentation/           # プロジェクトドキュメント
+├── rollup.config.mjs       # Rollup ビルド設定
+├── tsconfig.json           # TypeScript 設定
+├── jest.config.js          # Jest テスト設定
+└── package.json            # パッケージ情報
+```
+
+## ビルドプロセス
+
+```
+npm run build
+```
+
+1. `rimraf ./docs` — `docs/` ディレクトリを削除
+2. `rollup -c` — 以下を実行:
+   - TypeScript コンパイル
+   - SCSS を JS にインライン挿入
+   - npm パッケージをブラウザ向けにバンドル
+   - CommonJS → ESM 変換
+   - `process.env.NODE_ENV` を `'production'` に置換
+   - JSON インポート処理
+   - `public/index.html` と `src/style.json` を `docs/` にコピー
+   - UMD 形式で `docs/index.js` を出力（ソースマップ付き）
+
+出力されるバンドルのグローバル名は `City`。
+
+## クラス設計
+
+```
+@geolonia/maps-core GeoloniaMap
+  └── japan-maps-sdk GeoloniaMap（src/index.ts）
+       ├── データ読み込み系メソッド
+       │   ├── loadCSV / loadGeojson / loadData
+       │   ├── loadOsmPoi / removeOsmPoi
+       │   ├── loadHazardMapData / removeHazardMapData
+       │   ├── loadNLNIData / removeNLNIData
+       │   └── loadTottoriData / removeTottoriData
+       ├── スタイル変更系メソッド
+       │   ├── setBaseMapStyle
+       │   ├── setSymbolIconSize
+       │   ├── setCircleStyle / setFillStyle / setLineStyle
+       │   └── changeLayerIcon
+       ├── 地形・標高系メソッド
+       │   ├── show3DTerrain / hide3DTerrain
+       │   └── getElevation
+       ├── フィーチャクエリ系メソッド
+       │   ├── hasFeature
+       │   ├── getFeatures
+       │   └── getFeaturesProperties
+       ├── マーカー系メソッド
+       │   ├── addImageMarker / removeImageMarker
+       │   ├── removeAllImageMarkers
+       │   └── setImageMarkerWidth
+       └── 静的メソッド・プロパティ
+           ├── getOsmPoiLayers / getHazardMapData / getNLNIData
+           ├── getBaseMapStyles / getTottoriData
+           ├── getIconNames / getIconStyles
+           ├── fetchPrefNames / fetchCityNames
+           ├── getLatLngByPrefecture / getLatLngByCity
+           ├── spriteSheetUrl
+           └── baseMapStyleUrl
+```
+
+## テスト
+
+```
+npm test
+```
+
+Jest + ts-jest で jsdom 環境上でテストを実行する。テストファイルは `tests/` ディレクトリに各ユーティリティモジュールに対応する形で配置されている。
+
+## デプロイ
+
+`docs/` ディレクトリが GitHub Pages で公開される。`npm run build` の出力がそのままデプロイ対象となる。
+
+## 主要な外部依存
+
+| パッケージ | 用途 |
+|-----------|------|
+| `@geolonia/maps-core` | 地図コアライブラリ（Geolonia 拡張版 MapLibre） |
+| `maplibre-gl` | 地図レンダリングエンジン |
+| `@geolonia/normalize-japanese-addresses` | 日本語住所の正規化・ジオコーディング |
+| `papaparse` | CSV パース |

--- a/documentation/data-sources.md
+++ b/documentation/data-sources.md
@@ -1,0 +1,186 @@
+# データソース
+
+Japan Maps SDK が提供する公共データソースの一覧と詳細。
+
+---
+
+## OSM POI（OpenStreetMap 地物）
+
+OpenStreetMap のベクタータイルから特定の POI カテゴリを表示する。
+
+### 利用方法
+
+```javascript
+// POI レイヤーを表示
+map.loadOsmPoi('restaurant', 'chizubouken-lab');
+
+// POI レイヤーを非表示
+map.removeOsmPoi('restaurant');
+
+// 利用可能な種別一覧を取得
+const layers = geolonia.japan.Map.getOsmPoiLayers();
+```
+
+### 対応 POI 種別
+
+| 英語名 | 日本語名 | 説明 |
+|--------|----------|------|
+| `restaurant` | レストラン | 飲食店 |
+| `cafe` | カフェ | カフェ・喫茶店 |
+| `fast-food` | ファストフード | ファストフード店 |
+| `convenience` | コンビニ | コンビニエンスストア |
+| `bank` | 銀行 | 銀行・ATM |
+| `hospital` | 病院 | 病院・診療所 |
+| `school` | 学校 | 小中高等学校 |
+| `college` | 大学 | 大学・専門学校 |
+| `railway` | 鉄道駅 | 鉄道路線・駅 |
+| `airport` | 空港 | 空港 |
+| `mountain` | 山 | 山・峰 |
+| `zoo` | 動物園 | 動物園 |
+| `parking` | 駐車場 | 駐車場 |
+| `castle` | 城 | 城・城跡 |
+| `museum` | 博物館 | 博物館・美術館 |
+| `park` | 公園 | 公園 |
+
+### スプライトシート
+
+POI アイコンの表示には以下のスプライトシートが利用可能。
+
+| キー | 用途 |
+|------|------|
+| `chizubouken-lab` | 地図ぼうけんラボ用アイコンセット |
+| `mapfan` | MapFan DB 用アイコンセット |
+| `smartmap` | スマートマップ用アイコンセット |
+| `basic` | Geolonia Basic スタイルのアイコン |
+
+---
+
+## ハザードマップ
+
+国土交通省等が提供する防災関連のラスタータイルデータ。
+
+### 利用方法
+
+```javascript
+// ハザードマップを表示
+map.loadHazardMapData('flood');
+
+// ハザードマップを非表示
+map.removeHazardMapData('flood');
+
+// 利用可能なハザードマップ一覧を取得
+const hazardMaps = geolonia.japan.Map.getHazardMapData();
+```
+
+### 対応ハザードマップ種別
+
+洪水浸水想定、高潮浸水想定、津波浸水想定、土砂災害警戒区域、雪崩危険区域など 12 種類。詳細は `getHazardMapData()` の戻り値で確認可能。
+
+---
+
+## 国土数値情報（NLNI）
+
+国土交通省が提供する国土数値情報のベクタータイルデータ。
+
+### 利用方法
+
+```javascript
+// NLNI データを表示
+map.loadNLNIData('school');
+
+// NLNI データを非表示
+map.removeNLNIData('school');
+
+// 利用可能なデータ一覧を取得
+const nlniData = geolonia.japan.Map.getNLNIData();
+```
+
+### 対応データ種別
+
+| 種別 | 説明 |
+|------|------|
+| 小学校区 | 小学校の学区境界 |
+| 中学校区 | 中学校の学区境界 |
+| 学校 | 学校の位置情報 |
+| 医療機関 | 病院・診療所の位置情報 |
+| 人口推計 | メッシュ別人口推計 |
+| 駅乗降客数 | 鉄道駅の乗降客数 |
+| 市区町村役場 | 市区町村役場の位置情報 |
+| 盛土地図 | 盛土箇所の分布 |
+
+---
+
+## 鳥取県スマートシティデータ
+
+鳥取県スマートシティプロジェクトが提供する各種地理空間データ。ラスタータイルとベクタータイルの両形式に対応。
+
+### 利用方法
+
+```javascript
+// データ一覧を取得
+const tottoriData = await geolonia.japan.Map.getTottoriData();
+
+// データを表示
+map.loadTottoriData('data-id');
+
+// データを非表示
+map.removeTottoriData('data-id');
+```
+
+データの一覧は外部の `index.json` から動的に取得される。各エントリは以下の情報を持つ:
+
+```typescript
+type TottoriDataEntry = {
+  id: string;          // データ ID
+  tileUrl: string;     // タイル URL
+  styleUrl: string;    // スタイル URL
+  geojsonUrl?: string; // GeoJSON URL（任意）
+  description: string; // 説明
+};
+```
+
+---
+
+## 行政区域データ
+
+日本の都道府県・市区町村の行政区域境界 GeoJSON データ。
+
+### 利用方法
+
+```javascript
+import {
+  fetchPrefectureGeojson,
+  fetchMunicipalityGeojson,
+} from './utils/japaneseAdminsUtils';
+
+// 都道府県 GeoJSON（2桁の都道府県コード）
+const pref = await fetchPrefectureGeojson('13'); // 東京都
+
+// 市区町村 GeoJSON（5桁の行政区域コード）
+const city = await fetchMunicipalityGeojson('13101'); // 千代田区
+```
+
+---
+
+## 背景地図スタイル
+
+### 利用方法
+
+```javascript
+// スタイルを切り替え
+map.setBaseMapStyle(geolonia.japan.Map.baseMapStyleUrl['basic']);
+
+// 利用可能なスタイル一覧
+const styles = geolonia.japan.Map.getBaseMapStyles();
+```
+
+### 利用可能なスタイル
+
+| キー | 説明 |
+|------|------|
+| `basic` | Geolonia 標準スタイル |
+| `hakuchizu` | 白地図 |
+| `hakuchizu-nolabel` | 白地図（ラベルなし） |
+| `hakuchizu-notext` | 白地図（テキストなし） |
+
+デモページではさらに標準、国土地理院スマートマップ、衛星写真、ゲーム風スタイルを選択可能。

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -1,0 +1,87 @@
+# Getting Started
+
+## CDN での利用
+
+HTML に以下の script タグを追加する。`YOUR-API-KEY` は [Geolonia](https://geolonia.com/) で発行した API キーに置き換える。
+
+```html
+<script src="https://geolonia.github.io/japan-cityos-sdk/index.js?api-key=YOUR-API-KEY"></script>
+```
+
+## 地図の作成
+
+```html
+<div id="map" style="width: 100%; height: 400px;"></div>
+
+<script>
+const map = new geolonia.japan.Map({
+  container: 'map',
+  lngLat: [139.6917, 35.6895],
+  zoom: 12,
+});
+</script>
+```
+
+### コンストラクタオプション
+
+| パラメータ | 型 | 説明 |
+|-----------|------|------|
+| `container` | `string` | 地図を描画する要素の ID（省略時は `'map'`） |
+| `lngLat` | `[number, number]` | 初期表示の中心座標 `[経度, 緯度]` |
+| `zoom` | `number` | 初期ズームレベル |
+| `hash` | `boolean` | URL ハッシュに座標・ズームを同期するか |
+| `style` | `string` | 背景地図スタイルの URL |
+
+## CSV データの読み込み
+
+CSV ファイルから地図上にマーカーを表示する。CSV には緯度・経度カラムが必要（`lat`/`lng`、`latitude`/`longitude` などを自動検出）。
+
+```javascript
+const url = 'https://example.com/data.csv';
+map.loadCSV(url, 'layer-name', {
+  'marker-color': '#eba037',
+});
+```
+
+## GeoJSON データの読み込み
+
+```javascript
+map.loadGeojson(geojsonData, 'layer-name', {
+  'marker-symbol': 'chizubouken-lab:cafe',
+  'marker-size': 'large',
+  'title': ['get', 'name'],
+});
+```
+
+## データの削除
+
+```javascript
+map.removeGeojsonLayer('layer-name');
+```
+
+## グローバル API
+
+CDN 経由で読み込んだ場合、以下のグローバルオブジェクトが使用可能。
+
+```javascript
+window.geolonia.japan.Map       // GeoloniaMap クラス
+window.geolonia.japan.Popup     // maplibregl.Popup
+window.geolonia.japan.Marker    // maplibregl.Marker
+window.geolonia.japan.geometry  // 地理座標計算ユーティリティ
+window.geolonia.API_KEY         // script タグから取得した API キー
+```
+
+## デモページ
+
+[https://geolonia.github.io/japan-cityos-sdk/](https://geolonia.github.io/japan-cityos-sdk/)
+
+デモページでは以下の機能を試すことができる:
+
+- 背景地図の切り替え
+- 都道府県・市区町村の選択による地図移動
+- OSM POI レイヤーの表示
+- ハザードマップの重畳表示
+- 国土数値情報データの表示
+- 3D 地形表示
+- 標高取得
+- レイヤースタイルの動的変更

--- a/documentation/utilities.md
+++ b/documentation/utilities.md
@@ -1,0 +1,234 @@
+# ユーティリティ関数リファレンス
+
+`src/utils/` に含まれるユーティリティモジュールの詳細リファレンス。
+
+---
+
+## 地理座標計算 (`geometryUtils.ts`)
+
+MapLibre GL に依存しない純粋な地理座標計算関数群。`window.geolonia.japan.geometry` としてグローバルに公開される。
+
+### `distanceBetweenPoints(from, to)`
+
+2 点間の距離をメートル単位で計算する（Haversine 公式）。
+
+- **from** `[number, number]` — `[経度, 緯度]`
+- **to** `[number, number]` — `[経度, 緯度]`
+- **戻り値** `number` — 距離（メートル）
+
+### `bearingBetweenPoints(from, to)`
+
+2 点間の方位角を計算する（球面三角法）。
+
+- **from** `[number, number]` — `[経度, 緯度]`
+- **to** `[number, number]` — `[経度, 緯度]`
+- **戻り値** `number` — 方位角（0-360 度）
+
+### `nearestPointOnSegment(p, a, b)`
+
+点 P から線分 AB への最近点を求める（余弦緯度補正付き）。
+
+- **p** `[number, number]` — 対象点
+- **a** `[number, number]` — 線分の始点
+- **b** `[number, number]` — 線分の終点
+- **戻り値** `NearestPointOnSegmentResult`
+
+```typescript
+interface NearestPointOnSegmentResult {
+  point: [number, number]; // 最近点の座標
+  distance: number;        // 距離
+  t: number;               // 線分上の位置（0-1）
+}
+```
+
+### `nearestPointOnLine(point, lineCoords)`
+
+点からポリラインへの最近点を求める。
+
+- **point** `[number, number]` — 対象点
+- **lineCoords** `[number, number][]` — ポリラインの座標列
+- **戻り値** `NearestPointOnLineResult | null`
+
+```typescript
+interface NearestPointOnLineResult {
+  point: [number, number]; // 最近点の座標
+  distance: number;        // 距離
+  segmentIndex: number;    // 最近セグメントのインデックス
+  t: number;               // セグメント上の位置（0-1）
+}
+```
+
+### `collectLineFeatures(geojson)`
+
+GeoJSON FeatureCollection から LineString / MultiLineString フィーチャを抽出する。
+
+- **geojson** `GeoJSON.FeatureCollection`
+- **戻り値** `LineFeatureEntry[]`
+
+```typescript
+interface LineFeatureEntry {
+  coordinates: number[][]; // ライン座標列
+  feature: GeoJSON.Feature; // 元のフィーチャ
+}
+```
+
+---
+
+## GeoJSON ユーティリティ (`geojsonUtils.ts`)
+
+### `parseGeojsonInput(geojson)`
+
+入力値を GeoJSON FeatureCollection またはURL文字列としてパースする。
+
+- **geojson** `any` — JSON 文字列、URL 文字列、または GeoJSON オブジェクト
+- **戻り値** `string | GeoJSON.FeatureCollection | undefined`
+
+### `getGeometryTypes(geojson)`
+
+GeoJSON からジオメトリ型の一覧を抽出する。
+
+- **geojson** `GeoJSON.FeatureCollection | string`
+- **戻り値** `string[]` — `['Point', 'LineString', 'Polygon']` など
+
+---
+
+## CSV ユーティリティ (`mapUtils.ts`)
+
+### `csvToGeoJSON(data)`
+
+CSV データ（オブジェクト配列）を GeoJSON FeatureCollection に変換する。
+
+- **data** `any[]` — CSV パース済みの行データ
+- **戻り値** `GeoJSON.FeatureCollection`
+
+緯度・経度カラムは以下の名前を自動検出:
+`lat`/`lng`, `latitude`/`longitude`, `緯度`/`経度` など。
+
+---
+
+## ソース管理 (`sourceUtils.ts`)
+
+### `addOrUpdateGeojsonSource(map, className, geojson)`
+
+GeoJSON ソースを追加、または既存ソースのデータを更新する。
+
+- **map** `maplibregl.Map`
+- **className** `string` — ソース ID
+- **geojson** `GeoJSON.FeatureCollection | string` — データまたは URL
+
+---
+
+## レイヤー管理 (`layerUtils.ts`)
+
+### `addOrUpdateLayers(map, className, geometryTypes, simpleStyle?)`
+
+ジオメトリ型に応じたレイヤーを作成し、追加または更新する。
+
+### `getLayerIdsBySource(layers, sourceId)`
+
+指定ソース ID に属するレイヤー ID の一覧を取得する。
+
+---
+
+## レイヤーファクトリ (`createLayer.ts`)
+
+### `createSymbolLayer(className, simpleStyle, options?)`
+
+シンボルレイヤー（アイコン + テキスト）を作成する。
+
+### `createCircleLayer(className, simpleStyle, options?)`
+
+サークルレイヤーを作成する。
+
+### `createLineLayer(className, simpleStyle, options?)`
+
+ラインレイヤーを作成する。
+
+### `createFillLayer(className, simpleStyle?, options?)`
+
+ポリゴン（塗りつぶし）レイヤーを作成する。
+
+### `createLayersByGeometryTypes(className, geometryTypes, simpleStyle?, options?)`
+
+ジオメトリ型の配列から適切なレイヤー群を一括生成する。
+
+各関数の `options`:
+
+```typescript
+{
+  sourceLayer?: string;           // ベクタータイルのソースレイヤー名
+  filter?: FilterSpecification;   // MapLibre フィルタ式
+}
+```
+
+---
+
+## スプライト管理 (`spriteUtils.ts`)
+
+### `getSpriteIconNames(spriteSheetUrl)`
+
+スプライトシートに含まれるアイコン名一覧を取得する。
+
+- **spriteSheetUrl** `string` — スプライト JSON の URL
+- **戻り値** `Promise<string[]>`
+
+### `getSpriteIconStyles(spriteSheetUrl)`
+
+各アイコンの HTML 表示用 CSS スタイルを取得する。
+
+- **戻り値** `Promise<{width, height, backgroundImage, backgroundPosition}[]>`
+
+### `existsSpriteIcon(spriteSheetUrl, iconName)`
+
+指定アイコンがスプライトシートに存在するか確認する。
+
+- **戻り値** `Promise<boolean>`
+
+---
+
+## 住所・座標変換 (`resolveLatLng.ts`)
+
+### `resolveLatLng(address)`
+
+日本語住所を座標に変換する（`@geolonia/normalize-japanese-addresses` を使用）。
+
+- **address** `string` — 都道府県名、または「都道府県名 市区町村名」
+- **戻り値** `Promise<[number, number] | null>` — `[経度, 緯度]`
+
+---
+
+## 行政区域 (`japaneseAdminsUtils.ts`)
+
+### `buildJapaneseAdminsUrl(code)`
+
+行政区域コードから GeoJSON URL を構築する。
+
+### `fetchPrefectureGeojson(prefCode)`
+
+都道府県境界の GeoJSON を取得する（2 桁コード）。
+
+### `fetchMunicipalityGeojson(adminCode)`
+
+市区町村境界の GeoJSON を取得する（5 桁コード）。
+
+---
+
+## API キー解析 (`mapUtils.ts`)
+
+### `parseApiKey(script)`
+
+script 要素の `src` 属性 URL から `api-key` パラメータを抽出する。
+
+- **script** `HTMLScriptElement`
+- **戻り値** `string | null`
+
+---
+
+## HTTP ユーティリティ (`fetchJson.ts`)
+
+### `fetchJson(url)`
+
+URL から JSON を取得してパースする。エラー時は `null` を返す。
+
+- **url** `string`
+- **戻り値** `Promise<any | null>`

--- a/public/index.html
+++ b/public/index.html
@@ -505,7 +505,7 @@
 
   <div id="center-crosshair"></div>
   <div id="map"></div>
-  <script src="./index.js"></script>
+  <script src="./index.js?api-key=e3b7017e263c4bb39267b11a469ba286"></script>
   <script type="application/javascript">
     // セクション折りたたみ
     function toggleSection(sectionId) {


### PR DESCRIPTION
## Summary

### 1. デモページ 403 エラー修正

- デモページ（`docs/index.html`、`public/index.html`）の `<script>` タグに `?api-key=` パラメータで Geolonia APIキーを追加
- maps-core 移行時（#97）に script タグからAPIキーが削除され、`parseApiKey()` が空文字を返すためタイルサーバーが 403 Forbidden を返していた
- Geolonia embed API の正規パターンである `?api-key=` パラメータでAPIキーを渡すよう修正

### 2. プロジェクトドキュメント追加

`documentation/` ディレクトリに全体仕様ドキュメントを新規作成:

| ファイル | 内容 |
|---------|------|
| `getting-started.md` | 導入ガイド・CDN利用方法・基本的な使い方 |
| `api-reference.md` | GeoloniaMap クラスの全メソッド・プロパティ |
| `data-sources.md` | OSM POI・ハザードマップ・国土数値情報等のデータソース一覧 |
| `architecture.md` | 技術スタック・ビルドプロセス・ディレクトリ構造・クラス設計 |
| `utilities.md` | ユーティリティ関数（座標計算・GeoJSON パース等）の詳細リファレンス |

`README.md` を全面改訂し、ディレクトリ構成・機能一覧・ドキュメントへのリンクを追加。

## Functional Verification Criteria

- [ ] `https://geolonia.github.io/japan-cityos-sdk/` にアクセスして地図タイルが正常に表示される
- [ ] ブラウザの開発者ツールで 403 エラーが発生していないことを確認
- [ ] README.md のドキュメントリンクが正しく遷移する
- [ ] documentation/ 配下の各 md ファイルが GitHub 上で正しくレンダリングされる

## Review Criteria

- [ ] APIキーはドメイン制限付き公開キーであり、HTML埋め込みは Geolonia embed API の設計意図通り
- [ ] ドキュメントの API 記述がソースコードの実装と一致している
- [ ] ディレクトリ構成の記述が実際のファイル構造と一致している

## Test plan

- [x] `npm run build` が成功する
- [x] `npm test` で全41テストスイート（230テスト）がパスする